### PR TITLE
use offsetWidth and offsetHeight instead of getAttribute

### DIFF
--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -133,10 +133,7 @@ export class LayerManager {
     svgContainer.setAttribute('class', 'axis');
     container.appendChild(svgContainer);
 
-    const svg = select(svgContainer)
-      .append('svg')
-      .attr('height', `${container.getAttribute('height')}px`)
-      .attr('width', `${container.getAttribute('width')}px`);
+    const svg = select(svgContainer).append('svg').attr('height', `${container.offsetHeight}px`).attr('width', `${container.offsetWidth}px`);
 
     const showLabels = true;
 


### PR DESCRIPTION
getAttribute would return null if the attribute was not set, offset returns a number and also bases off of actual dimensions