### PR TITLE
avoid negative dimensions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,5 @@
 export const DEFAULT_LAYER_WIDTH = 200;
 export const DEFAULT_LAYER_HEIGHT = 300;
+
+export const HORIZONTAL_AXIS_MARGIN = 40;
+export const VERTICAL_AXIS_MARGIN = 30;

--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -125,8 +125,8 @@ export class LayerManager {
   }
 
   adjustToSize(width: number, height: number): void {
-    const layersWidth = this._axis ? Math.max(width - HORIZONTAL_AXIS_MARGIN, 0) : width;
-    const layersHeight = this._axis ? Math.max(height - VERTICAL_AXIS_MARGIN, 0) : height;
+    const layersWidth = Math.max(this._axis ? width - HORIZONTAL_AXIS_MARGIN : width, 0);
+    const layersHeight = Math.max(this._axis ? height - VERTICAL_AXIS_MARGIN : height, 0);
 
     if (this._axis) {
       const resizeEvent = { width, height };

--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -125,8 +125,8 @@ export class LayerManager {
   }
 
   adjustToSize(width: number, height: number): void {
-    const layersWidth = this._axis && width !== 0 ? width - HORIZONTAL_AXIS_MARGIN : width;
-    const layersHeight = this._axis && height !== 0 ? height - VERTICAL_AXIS_MARGIN : height;
+    const layersWidth = this._axis ? Math.max(width - HORIZONTAL_AXIS_MARGIN, 0) : width;
+    const layersHeight = this._axis ? Math.max(height - VERTICAL_AXIS_MARGIN, 0) : height;
 
     if (this._axis) {
       const resizeEvent = { width, height };

--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -4,6 +4,7 @@ import { Layer, GridLayer } from '../layers';
 import { ScaleOptions, OnMountEvent, OnRescaleEvent } from '../interfaces';
 import { Axis } from '../components';
 import { IntersectionReferenceSystem } from './IntersectionReferenceSystem';
+import { HORIZONTAL_AXIS_MARGIN, VERTICAL_AXIS_MARGIN } from '../constants';
 
 interface AxisOptions {
   xLabel: string;
@@ -124,11 +125,8 @@ export class LayerManager {
   }
 
   adjustToSize(width: number, height: number): void {
-    const horizontalAxisMargin = 40;
-    const verticalAxisMargin = 30;
-
-    const layersWidth = this._axis ? width - horizontalAxisMargin : width;
-    const layersHeight = this._axis ? height - verticalAxisMargin : height;
+    const layersWidth = this._axis && width !== 0 ? width - HORIZONTAL_AXIS_MARGIN : width;
+    const layersHeight = this._axis && height !== 0 ? height - VERTICAL_AXIS_MARGIN : height;
 
     if (this._axis) {
       const resizeEvent = { width, height };

--- a/src/control/MainController.ts
+++ b/src/control/MainController.ts
@@ -118,7 +118,7 @@ export class Controller {
   adjustToSize(width: number, height: number): Controller {
     this.layerManager.adjustToSize(width, height);
 
-    const dimensions = { width: width !== 0 ? width - HORIZONTAL_AXIS_MARGIN : 0, height: height !== 0 ? height - VERTICAL_AXIS_MARGIN : 0 };
+    const dimensions = { width: Math.max(width - HORIZONTAL_AXIS_MARGIN, 0), height: Math.max(height - VERTICAL_AXIS_MARGIN, 0) };
     this.overlay.elm.dispatch('resize', { detail: dimensions, bubbles: true, cancelable: true });
 
     return this;

--- a/src/control/MainController.ts
+++ b/src/control/MainController.ts
@@ -6,9 +6,7 @@ import { ZoomPanHandler } from './ZoomPanHandler';
 import { ReferenceSystemOptions } from '..';
 import { Axis } from '../components';
 import { overlay, Overlay } from './overlay';
-
-const HORIZONTALAXISMARGIN = 40;
-const VERTICALAXISMARGIN = 30;
+import { HORIZONTAL_AXIS_MARGIN, VERTICAL_AXIS_MARGIN } from '../constants';
 
 /**
  * API for controlling data and layers
@@ -120,7 +118,7 @@ export class Controller {
   adjustToSize(width: number, height: number): Controller {
     this.layerManager.adjustToSize(width, height);
 
-    const dimensions = { width: width - HORIZONTALAXISMARGIN, height: height - VERTICALAXISMARGIN };
+    const dimensions = { width: width !== 0 ? width - HORIZONTAL_AXIS_MARGIN : 0, height: height !== 0 ? height - VERTICAL_AXIS_MARGIN : 0 };
     this.overlay.elm.dispatch('resize', { detail: dimensions, bubbles: true, cancelable: true });
 
     return this;


### PR DESCRIPTION
a bug encountered in REP where dimensions were 0 and a offset was added nonetheless