### PR TITLE
fix order not working for HTMLLayer

### DIFF
--- a/src/layers/base/HTMLLayer.ts
+++ b/src/layers/base/HTMLLayer.ts
@@ -25,7 +25,7 @@ export abstract class HTMLLayer extends Layer {
       .style('opacity', this.opacity)
       .style('overflow', 'hidden')
       .style('pointer-events', interactive)
-      .attr('z-index', this.order);
+      .style('z-index', this.order);
   }
 
   onUnmount(): void {
@@ -57,7 +57,7 @@ export abstract class HTMLLayer extends Layer {
 
   onOrderChanged(order: number): void {
     if (this.elm) {
-      this.elm.attr('z-index', order);
+      this.elm.style('z-index', order);
     }
   }
 

--- a/test/html-layer.test.ts
+++ b/test/html-layer.test.ts
@@ -64,10 +64,10 @@ describe('HTML', () => {
     const layer = new htmlLayer('well');
     layer.onMount({ elm });
     expect(layer.order).toEqual(1);
-    expect(layer.elm.attr('z-index')).toEqual('1');
+    expect(layer.elm.style('z-index')).toEqual('1');
     layer.order = 2;
     expect(layer.order).toEqual(2);
-    expect(layer.elm.attr('z-index')).toEqual('2');
+    expect(layer.elm.style('z-index')).toEqual('2');
   });
   it('should update opacity when changing its value', () => {
     const layer = new htmlLayer('well');


### PR DESCRIPTION
z-index is set as attribute on HTML layer, but needs to be set as CSS property