### PR TITLE
fix well layers rendering artifacts

### DIFF
--- a/.storybook/src/complete-example/intersection.stories.ts
+++ b/.storybook/src/complete-example/intersection.stories.ts
@@ -47,7 +47,6 @@ export const intersection = () => {
   Promise.all(promises).then((values) => {
     const [path, completion, seismic, surfaces, stratColumns, casings, holesizes, cement, picks] = values;
     const referenceSystem = new IntersectionReferenceSystem(path);
-    // referenceSystem.offset = path[0][2]
     const displacement = referenceSystem.displacement || 1;
     const extend = 1000 / displacement;
     const steps = surfaces[0]?.data?.values?.length || 1;

--- a/.storybook/src/complete-example/intersection.stories.ts
+++ b/.storybook/src/complete-example/intersection.stories.ts
@@ -47,6 +47,7 @@ export const intersection = () => {
   Promise.all(promises).then((values) => {
     const [path, completion, seismic, surfaces, stratColumns, casings, holesizes, cement, picks] = values;
     const referenceSystem = new IntersectionReferenceSystem(path);
+    // referenceSystem.offset = path[0][2]
     const displacement = referenceSystem.displacement || 1;
     const extend = 1000 / displacement;
     const steps = surfaces[0]?.data?.values?.length || 1;

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@equinor/videx-vector2": "^1.0.44",
     "@types/d3": "^5.7.2",
     "curve-interpolator": "2.0.8",
+    "d3-array": "^2.4.0",
     "d3-axis": "^1.0.12",
     "d3-scale": "^3.2.1",
     "d3-selection": "^1.4.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,5 @@ export const DEFAULT_LAYER_HEIGHT = 300;
 
 export const HORIZONTAL_AXIS_MARGIN = 40;
 export const VERTICAL_AXIS_MARGIN = 30;
+
+export const HOLE_OUTLINE = 1;

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -101,6 +101,14 @@ export class IntersectionReferenceSystem {
     return p;
   }
 
+  curtainTangent(length: number) {
+    const { curtain } = this.interpolators;
+    const l = (length - this._offset) / this.length;
+    const t = clamp(l, 0, 1);
+    const p = curtain.getTangentAt(t);
+    return p;
+  }
+
   /**
    * Map a displacement back to length along the curve
    */

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -14,7 +14,7 @@ const DEFAULT_START_EXTEND_LENGTH = 1000.0;
 const DEFAULT_END_EXTEND_LENGTH = 1000.0;
 
 const ALLOWED_ANGLE_CHANGE = 0.0005;
-const POINT_INCREMENT = 0.1;
+const CURTAIN_SAMPLING_INTERVAL = 0.1;
 
 export class IntersectionReferenceSystem {
   options: ReferenceSystemOptions;
@@ -120,7 +120,7 @@ export class IntersectionReferenceSystem {
     if (!this._curtainPathCache) {
       const points = [];
       let prevAngle = Math.PI * 2; // Always add first point
-      for (let i = this._offset; i <= this.length + this._offset; i += POINT_INCREMENT) {
+      for (let i = this._offset; i <= this.length + this._offset; i += CURTAIN_SAMPLING_INTERVAL) {
         const point = this.project(i);
         const angle = Math.atan2(point[1], point[0]);
 

--- a/src/datautils/wellboreItemShapeGenerator.ts
+++ b/src/datautils/wellboreItemShapeGenerator.ts
@@ -1,35 +1,27 @@
 import { Point } from 'pixi.js';
-import { HoleObjectData, NormalCoordsObject, MDPoint, Cement, Casing, HoleSize, CompiledCement } from '..';
-import { createNormals, pointToArray, arrayToPoint, offsetPoints } from '../utils/vectorUtils';
-import { CurveInterpolator } from 'curve-interpolator';
+import { HoleObjectData, NormalCoordsObject, Cement, Casing, HoleSize, CompiledCement } from '..';
+import { createNormals, offsetPoints } from '../utils/vectorUtils';
 
-export const generateHoleCoords = (normalOffsetCoordsUp: any, normalOffsetCoordsDown: any): any => {
+export const generateHoleCoords = (offsetCoordsRight: any, offsetCoordsLeft: any): any => {
   return {
-    left: normalOffsetCoordsUp,
-    right: normalOffsetCoordsDown.map((d: Point) => d.clone()).reverse(),
-    top: [normalOffsetCoordsUp[0], normalOffsetCoordsDown[0]],
-    bottom: [normalOffsetCoordsUp[normalOffsetCoordsUp.length - 1], normalOffsetCoordsDown[normalOffsetCoordsDown.length - 1]],
+    left: offsetCoordsRight,
+    right: offsetCoordsLeft.map((d: Point) => d.clone()).reverse(),
+    top: [offsetCoordsRight[0], offsetCoordsLeft[0]],
+    bottom: [offsetCoordsRight[offsetCoordsRight.length - 1], offsetCoordsLeft[offsetCoordsLeft.length - 1]],
   };
 };
 
-export const createNormalCoords = (s: HoleObjectData): NormalCoordsObject => {
+export const createOffsetCoords = (s: HoleObjectData): NormalCoordsObject => {
   const wellBorePathCoords = s.points.map((p) => p.point);
   const normals = createNormals(wellBorePathCoords);
-  const normalOffsetCoordsUpOrig = offsetPoints(wellBorePathCoords, normals, s.data.diameter);
-  const normalOffsetCoordsDownOrig = offsetPoints(wellBorePathCoords, normals, -s.data.diameter);
+  const offsetCoordsRight = offsetPoints(wellBorePathCoords, normals, s.data.diameter);
+  const offsetCoordsLeft = offsetPoints(wellBorePathCoords, normals, -s.data.diameter);
 
-  if (normalOffsetCoordsUpOrig.length <= 2) {
-    return { wellBorePathCoords, normalOffsetCoordsDown: wellBorePathCoords, normalOffsetCoordsUp: wellBorePathCoords };
+  if (offsetCoordsLeft.length <= 2) {
+    return { wellBorePathCoords, offsetCoordsRight: wellBorePathCoords, offsetCoordsLeft: wellBorePathCoords };
   }
 
-  const tension = 0.2;
-  const numPoints = 999;
-  const normalOffsetCoordsUpInterpolator = new CurveInterpolator(normalOffsetCoordsUpOrig.map(pointToArray), tension);
-  const normalOffsetCoordsDownInterpolator = new CurveInterpolator(normalOffsetCoordsDownOrig.map(pointToArray), tension);
-  const normalOffsetCoordsUp = normalOffsetCoordsUpInterpolator.getPoints(numPoints).map(arrayToPoint);
-  const normalOffsetCoordsDown = normalOffsetCoordsDownInterpolator.getPoints(numPoints).map(arrayToPoint);
-
-  return { wellBorePathCoords, normalOffsetCoordsDown, normalOffsetCoordsUp };
+  return { wellBorePathCoords, offsetCoordsRight, offsetCoordsLeft };
 };
 
 export const findCasing = (id: string, casings: any) => {

--- a/src/datautils/wellboreItemShapeGenerator.ts
+++ b/src/datautils/wellboreItemShapeGenerator.ts
@@ -1,7 +1,7 @@
 import { Point } from 'pixi.js';
 import { merge } from 'd3-array';
 import { HoleObjectData, NormalCoordsObject, Cement, Casing, HoleSize, CompiledCement } from '..';
-import { createNormals, offsetPoints } from '../utils/vectorUtils';
+import { offsetPoints } from '../utils/vectorUtils';
 
 export const generateHoleCoords = (offsetCoordsRight: any, offsetCoordsLeft: any): any => {
   return {
@@ -12,18 +12,18 @@ export const generateHoleCoords = (offsetCoordsRight: any, offsetCoordsLeft: any
   };
 };
 
-export const createOffsetCoords = (s: HoleObjectData): NormalCoordsObject => {
-  const wellBorePathCoords = s.points.map((p) => p.point);
-  const normals = createNormals(wellBorePathCoords);
-  const offsetCoordsRight = offsetPoints(wellBorePathCoords, normals, s.data.diameter);
-  const offsetCoordsLeft = offsetPoints(wellBorePathCoords, normals, -s.data.diameter);
+// export const createOffsetCoords = (s: HoleObjectData): NormalCoordsObject => {
+//   const wellBorePathCoords = s.points.map((p) => p.point);
+//   const normals = createNormals(wellBorePathCoords);
+//   const offsetCoordsRight = offsetPoints(wellBorePathCoords, normals, s.data.diameter);
+//   const offsetCoordsLeft = offsetPoints(wellBorePathCoords, normals, -s.data.diameter);
 
-  if (offsetCoordsLeft.length <= 2) {
-    return { wellBorePathCoords, offsetCoordsRight: wellBorePathCoords, offsetCoordsLeft: wellBorePathCoords };
-  }
+//   if (offsetCoordsLeft.length <= 2) {
+//     return { wellBorePathCoords, offsetCoordsRight: wellBorePathCoords, offsetCoordsLeft: wellBorePathCoords };
+//   }
 
-  return { wellBorePathCoords, offsetCoordsRight, offsetCoordsLeft };
-};
+//   return { wellBorePathCoords, offsetCoordsRight, offsetCoordsLeft };
+// };
 
 export const findCasing = (id: string, casings: any) => {
   const res = casings.filter((c: any) => c.casingId === id);

--- a/src/datautils/wellboreItemShapeGenerator.ts
+++ b/src/datautils/wellboreItemShapeGenerator.ts
@@ -1,6 +1,6 @@
 import { Point } from 'pixi.js';
 import { merge } from 'd3-array';
-import { Cement, Casing, HoleSize, CompiledCement } from '..';
+import { Cement, Casing, HoleSize } from '..';
 import { HOLE_OUTLINE } from '../constants';
 
 export const getEndLines = (
@@ -16,7 +16,7 @@ export const getEndLines = (
   };
 };
 
-export const getRopePolygon = (rightPath: Point[], leftPath: Point[]): Point[] => {
+export const makeTubularPolygon = (rightPath: Point[], leftPath: Point[]): Point[] => {
   return [
     ...leftPath,
     ...rightPath
@@ -56,23 +56,16 @@ export const findIntersectingItems = (
   };
 };
 
-export const compileCement = (cement: Cement, casings: Casing[], holes: HoleSize[]): CompiledCement => {
-  const attachedCasing = findCasing(cement.casingId, casings);
-  return {
-    ...cement,
-    boc: attachedCasing.end,
-    attachedCasing,
-    intersectingItems: findIntersectingItems(cement, attachedCasing, casings, holes),
-  };
-};
-
 export const cementDiameterChangeDepths = (
-  cement: CompiledCement,
+  cement: Cement,
+  bottomOfCement: number,
   diameterIntervals: {
     start: number;
     end: number;
   }[],
 ): number[] => {
+  const topOfCement = cement.toc;
+
   const diameterChangeDepths =
     merge(
       diameterIntervals.map((d) => [
@@ -81,10 +74,10 @@ export const cementDiameterChangeDepths = (
         d.end,
         d.end + 0.0001, // +- 0.0001 to find diameter right after object
       ]),
-    ).filter((d) => d >= cement.toc && d <= cement.boc) as number[]; // trim
+    ).filter((d) => d >= topOfCement && d <= bottomOfCement) as number[]; // trim
 
-  diameterChangeDepths.push(cement.toc);
-  diameterChangeDepths.push(cement.boc);
+  diameterChangeDepths.push(topOfCement);
+  diameterChangeDepths.push(bottomOfCement);
 
   const uniqDepths = uniq(diameterChangeDepths);
 

--- a/src/datautils/wellboreItemShapeGenerator.ts
+++ b/src/datautils/wellboreItemShapeGenerator.ts
@@ -1,4 +1,5 @@
 import { Point } from 'pixi.js';
+import { merge } from 'd3-array';
 import { HoleObjectData, NormalCoordsObject, Cement, Casing, HoleSize, CompiledCement } from '..';
 import { createNormals, offsetPoints } from '../utils/vectorUtils';
 
@@ -31,15 +32,96 @@ export const findCasing = (id: string, casings: any) => {
 
 export const overlaps = (top1: number, bottom1: number, top2: number, bottom2: number): boolean => top1 <= bottom2 && top2 <= bottom1;
 
-export const findIntersectingItems = (cement: Cement, parentCasing: Casing, casings: Casing[], holes: HoleSize[]) => {
-  const { toc: start } = cement;
+export const uniq = <T>(arr: T[]): T[] => Array.from<T>(new Set(arr));
 
-  const res = [];
-  res.push(...holes.filter((h: HoleSize) => overlaps(start, parentCasing.end, h.start, h.end) && h.diameter > parentCasing.diameter));
-  res.push(
-    ...casings.filter(
-      (c: Casing) => c.casingId !== cement.casingId && overlaps(start, parentCasing.end, c.start, c.end) && c.diameter > parentCasing.diameter,
-    ),
+export const findIntersectingItems = (
+  cement: Cement,
+  parentCasing: Casing,
+  casings: Casing[],
+  holes: HoleSize[],
+): { holes: HoleSize[]; casings: Casing[] } => {
+  const { toc: start } = cement;
+  const { end } = parentCasing;
+  const overlappingHoles = holes.filter((h: HoleSize) => overlaps(start, end, h.start, h.end) && h.diameter > parentCasing.diameter);
+  const overlappingCasings = casings.filter(
+    (c: Casing) => c.casingId !== cement.casingId && overlaps(start, end, c.start, c.end) && c.diameter > parentCasing.diameter,
   );
+
+  return {
+    holes: overlappingHoles,
+    casings: overlappingCasings,
+  };
+};
+
+export const parseCement = (cement: Cement, casings: Casing[], holes: HoleSize[]): CompiledCement => {
+  const attachedCasing = findCasing(cement.casingId, casings);
+  const res: CompiledCement = {
+    ...cement,
+    boc: attachedCasing.end,
+    attachedCasing,
+    intersectingItems: findIntersectingItems(cement, attachedCasing, casings, holes),
+  };
   return res;
+};
+
+export const cementDiameterChangeDepths = (
+  cement: CompiledCement,
+  diameterIntervals: {
+    start: number;
+    end: number;
+  }[],
+): number[] => {
+  const diameterChangeDepths =
+    merge(
+      diameterIntervals.map((d) => [
+        // +- 0.0001 to find diameter right before/after object
+        d.start - 0.0001,
+        d.start,
+        d.end,
+        d.end + 0.0001,
+      ]),
+    ).filter((d) => d >= cement.toc && d <= cement.boc) as number[]; // trim
+
+  diameterChangeDepths.push(cement.toc);
+  diameterChangeDepths.push(cement.boc);
+
+  const uniqDepths = uniq(diameterChangeDepths);
+
+  return uniqDepths.sort((a: number, b: number) => a - b);
+};
+
+export const calculateCementDiameter = (innerCasing: Casing, nonAttachedCasings: Casing[], holes: HoleSize[]) => (
+  depth: number,
+): {
+  md: number;
+  innerDiameter: number;
+  outerDiameter: number;
+} => {
+  const defaultCementWidth = 100; // Default to flow cement outside to show error in data
+
+  const innerDiameter = innerCasing ? innerCasing.diameter : 0;
+
+  const outerCasings = nonAttachedCasings.filter((casing) => casing.innerDiameter > innerDiameter);
+  const holeAtDepth = holes.find((casing) => casing.start <= depth && casing.end >= depth);
+
+  const outerObjectAtDepth = [...outerCasings, holeAtDepth]
+    .filter((d) => d)
+    .sort((a, b) => {
+      const aDim = a.innerDiameter ? a.innerDiameter : a.diameter;
+      const bDim = b.innerDiameter ? b.innerDiameter : b.diameter;
+      return aDim - bDim;
+    }) // ascending
+    .find((object) => object.start <= depth && object.end >= depth);
+
+  const outerDiameter = outerObjectAtDepth
+    ? outerObjectAtDepth.innerDiameter
+      ? outerObjectAtDepth.innerDiameter
+      : outerObjectAtDepth.diameter - 1 // TODO explain this. Don't overlap hole wall. 1 = hole wall thickness?
+    : defaultCementWidth;
+
+  return {
+    md: depth,
+    innerDiameter,
+    outerDiameter,
+  };
 };

--- a/src/datautils/wellboreItemShapeGenerator.ts
+++ b/src/datautils/wellboreItemShapeGenerator.ts
@@ -1,6 +1,6 @@
 import { Point } from 'pixi.js';
 import { HoleObjectData, NormalCoordsObject, MDPoint, Cement, Casing, HoleSize, CompiledCement } from '..';
-import { createNormal, pointToArray, arrayToPoint } from '../utils/vectorUtils';
+import { createNormals, pointToArray, arrayToPoint, offsetPoints } from '../utils/vectorUtils';
 import { CurveInterpolator } from 'curve-interpolator';
 
 export const generateHoleCoords = (normalOffsetCoordsUp: any, normalOffsetCoordsDown: any): any => {
@@ -13,9 +13,10 @@ export const generateHoleCoords = (normalOffsetCoordsUp: any, normalOffsetCoords
 };
 
 export const createNormalCoords = (s: HoleObjectData): NormalCoordsObject => {
-  const wellBorePathCoords = actualPoints(s);
-  const normalOffsetCoordsUpOrig = createNormal(wellBorePathCoords, s.data.diameter);
-  const normalOffsetCoordsDownOrig = createNormal(wellBorePathCoords, -s.data.diameter);
+  const wellBorePathCoords = s.points.map((p) => p.point);
+  const normals = createNormals(wellBorePathCoords);
+  const normalOffsetCoordsUpOrig = offsetPoints(wellBorePathCoords, normals, s.data.diameter);
+  const normalOffsetCoordsDownOrig = offsetPoints(wellBorePathCoords, normals, -s.data.diameter);
 
   if (normalOffsetCoordsUpOrig.length <= 2) {
     return { wellBorePathCoords, normalOffsetCoordsDown: wellBorePathCoords, normalOffsetCoordsUp: wellBorePathCoords };
@@ -29,32 +30,6 @@ export const createNormalCoords = (s: HoleObjectData): NormalCoordsObject => {
   const normalOffsetCoordsDown = normalOffsetCoordsDownInterpolator.getPoints(numPoints).map(arrayToPoint);
 
   return { wellBorePathCoords, normalOffsetCoordsDown, normalOffsetCoordsUp };
-};
-
-export const actualPoints = (s: HoleObjectData): Point[] => {
-  let start = new Point();
-  let stop = new Point();
-  let startIndex = 0;
-  let stopIndex = 0;
-  const a = s.points.filter((p: MDPoint, index: number) => {
-    if (s.data.start > p.md) {
-      startIndex = index;
-    }
-    if (s.data.end >= p.md) {
-      stopIndex = index;
-    }
-    return p.md > s.data.start && p.md < s.data.end;
-  });
-
-  if (a == null || a.length === 0) {
-    return [];
-  }
-
-  startIndex -= 0;
-  stopIndex += 0;
-  start = s.points[startIndex >= 0 ? startIndex : 0].point;
-  stop = s.points[stopIndex <= s.points.length ? stopIndex : s.points.length - 1].point;
-  return [start, ...a.map((b: MDPoint) => b.point), stop];
 };
 
 export const findCasing = (id: string, casings: any) => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -125,7 +125,6 @@ export interface HoleSize {
   diameter: number;
   start: number;
   end: number;
-  hasShoe?: boolean;
   innerDiameter?: number;
 }
 
@@ -156,13 +155,6 @@ export interface MDPoint {
   point: Point;
   normal?: Vector2;
   md: number; // Currently calculated MD
-}
-
-export interface HoleObjectData {
-  data: HoleSize;
-  points: MDPoint[];
-  hasShoe?: boolean;
-  innerDiameter?: number;
 }
 
 export interface WellItemGraphics {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -93,7 +93,6 @@ export interface WellComponentBaseOptions extends LayerOptions {
   maxFontSize?: number;
   textColor?: string;
   font?: string;
-  wellboreBaseComponentIncrement?: number;
 }
 
 export interface GeoModelData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -165,8 +165,8 @@ export interface WellItemGraphics {
 
 export interface NormalCoordsObject {
   wellBorePathCoords: Point[];
-  normalOffsetCoordsDown: Point[];
-  normalOffsetCoordsUp: Point[];
+  offsetCoordsRight: Point[];
+  offsetCoordsLeft: Point[];
 }
 
 export interface ScaleOptions {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -135,22 +135,6 @@ export interface Casing {
   innerDiameter: number;
   casingId: string;
 }
-export interface CompiledCement {
-  toc: number;
-  boc: number;
-  casingId: string;
-  attachedCasing: Casing;
-  intersectingItems: {
-    holes: HoleSize[];
-    outerCasings: Casing[];
-  };
-}
-
-export interface CementShape {
-  rightPolygon: Point[];
-  leftPolygon: Point[];
-  path: Point[];
-}
 export interface Cement {
   toc: number;
   casingId: string; // TODO find the actual ID

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -141,7 +141,11 @@ export interface CompiledCement {
   toc: number;
   boc: number;
   casingId: string;
-  intersectingItems: any;
+  attachedCasing: Casing;
+  intersectingItems: {
+    holes: HoleSize[];
+    casings: Casing[];
+  };
 }
 export interface Cement {
   toc: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ import { ZoomTransform } from 'd3-zoom';
 import { Point, Graphics } from 'pixi.js';
 import { Layer } from './layers/base/Layer';
 import { IntersectionReferenceSystem } from './control/IntersectionReferenceSystem';
+import Vector2 from '@equinor/videx-vector2';
 
 interface LayerEvent {
   [propType: string]: any;
@@ -149,6 +150,7 @@ export interface Cement {
 
 export interface MDPoint {
   point: Point;
+  normal?: Vector2;
   md: number; // Currently calculated MD
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -145,6 +145,12 @@ export interface CompiledCement {
     outerCasings: Casing[];
   };
 }
+
+export interface CementShape {
+  rightPolygon: Point[];
+  leftPolygon: Point[];
+  path: Point[];
+}
 export interface Cement {
   toc: number;
   casingId: string; // TODO find the actual ID

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -142,7 +142,7 @@ export interface CompiledCement {
   attachedCasing: Casing;
   intersectingItems: {
     holes: HoleSize[];
-    casings: Casing[];
+    outerCasings: Casing[];
   };
 }
 export interface Cement {
@@ -158,12 +158,6 @@ export interface MDPoint {
 
 export interface WellItemGraphics {
   graphics: Graphics;
-}
-
-export interface NormalCoordsObject {
-  wellBorePathCoords: Point[];
-  offsetCoordsRight: Point[];
-  offsetCoordsLeft: Point[];
 }
 
 export interface ScaleOptions {

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -1,7 +1,7 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { CasingLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, Casing } from '..';
-import { Texture, Point } from 'pixi.js';
-import { getEndLines, getRopePolygon } from '../datautils/wellboreItemShapeGenerator';
+import { Point } from 'pixi.js';
+import { getEndLines, makeTubularPolygon } from '../datautils/wellboreItemShapeGenerator';
 import { offsetPoints, offsetPoint } from '../utils/vectorUtils';
 import { MDPoint } from '../interfaces';
 
@@ -64,12 +64,11 @@ export class CasingLayer extends WellboreBaseComponentLayer {
     const leftPath = offsetPoints(pathPoints, normals, -casing.diameter);
 
     const { top, bottom } = getEndLines(rightPath, leftPath);
-    const polygon = getRopePolygon(leftPath, rightPath);
+    const polygon = makeTubularPolygon(leftPath, rightPath);
 
     const casingWallWidth = Math.abs(casing.diameter - casing.innerDiameter);
 
     this.drawRope(pathPoints, texture);
-
     this.drawLine(polygon, lineColor, casingWallWidth);
     this.drawLine(top, topBottomLineColor, 1);
     this.drawLine(bottom, topBottomLineColor, 1);

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -42,8 +42,6 @@ export class CasingLayer extends WellboreBaseComponentLayer {
       return;
     }
 
-    const { maxTextureDiameterScale, firstColor, secondColor } = this.options;
-
     data
       .sort((a: Casing, b: Casing) => b.diameter - a.diameter) // draw smaller casings and holes on top of bigger ones if overlapping
       .forEach((casing: Casing) => this.drawCasing(casing));
@@ -54,9 +52,9 @@ export class CasingLayer extends WellboreBaseComponentLayer {
       return;
     }
     const pctOffset = 0.35;
-    const { maxTextureDiameterScale, firstColor, secondColor, lineColor, topBottomLineColor } = this.options;
+    const { maxTextureDiameterScale, lineColor, topBottomLineColor } = this.options;
 
-    const texture = this.createTexure(casing.diameter * maxTextureDiameterScale, firstColor, secondColor, pctOffset);
+    const texture = this.createTexture(casing.diameter * maxTextureDiameterScale, pctOffset);
 
     const path = this.getPathWithNormals(casing.start, casing.end, []);
 

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -1,7 +1,7 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { CasingLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, HoleObjectData, Casing } from '..';
 import { Texture, Point } from 'pixi.js';
-import { createNormalCoords, generateHoleCoords } from '../datautils/wellboreItemShapeGenerator';
+import { createOffsetCoords, generateHoleCoords } from '../datautils/wellboreItemShapeGenerator';
 import { createNormals, arrayToPoint, offsetPoints } from '../utils/vectorUtils';
 
 export class CasingLayer extends WellboreBaseComponentLayer {
@@ -58,9 +58,9 @@ export class CasingLayer extends WellboreBaseComponentLayer {
     }
 
     const { maxTextureDiameterScale, firstColor, secondColor, lineColor, topBottomLineColor } = this.options;
-    const { wellBorePathCoords, normalOffsetCoordsDown, normalOffsetCoordsUp } = createNormalCoords(holeObject);
+    const { wellBorePathCoords, offsetCoordsLeft, offsetCoordsRight } = createOffsetCoords(holeObject);
 
-    const { top, bottom, left, right } = generateHoleCoords(normalOffsetCoordsUp, normalOffsetCoordsDown);
+    const { top, bottom, left, right } = generateHoleCoords(offsetCoordsRight, offsetCoordsLeft);
     const polygonCoords = [...left, ...right];
     const mask = this.drawBigPolygon(polygonCoords);
     let texture = defaultTexture;

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -58,19 +58,19 @@ export class CasingLayer extends WellboreBaseComponentLayer {
 
     const path = this.getPathWithNormals(casing.start, casing.end, []);
 
-    const points = path.map((p) => p.point);
+    const pathPoints = path.map((p) => p.point);
     const normals = path.map((p) => p.normal);
-    const rightPath = offsetPoints(points, normals, casing.diameter);
-    const leftPath = offsetPoints(points, normals, -casing.diameter);
+    const rightPath = offsetPoints(pathPoints, normals, casing.diameter);
+    const leftPath = offsetPoints(pathPoints, normals, -casing.diameter);
 
     const { top, bottom } = getEndLines(rightPath, leftPath);
-    const polygonCoords = getRopePolygon(leftPath, rightPath);
+    const polygon = getRopePolygon(leftPath, rightPath);
 
     const casingWallWidth = Math.abs(casing.diameter - casing.innerDiameter);
 
-    this.drawRope(points, texture);
+    this.drawRope(pathPoints, texture);
 
-    this.drawLine(polygonCoords, lineColor, casingWallWidth);
+    this.drawLine(polygon, lineColor, casingWallWidth);
     this.drawLine(top, topBottomLineColor, 1);
     this.drawLine(bottom, topBottomLineColor, 1);
 

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -2,7 +2,7 @@ import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { CasingLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, HoleObjectData, Casing } from '..';
 import { Texture, Point } from 'pixi.js';
 import { createNormalCoords, generateHoleCoords } from '../datautils/wellboreItemShapeGenerator';
-import { createNormal, arrayToPoint } from '../utils/vectorUtils';
+import { createNormals, arrayToPoint, offsetPoints } from '../utils/vectorUtils';
 
 export class CasingLayer extends WellboreBaseComponentLayer {
   options: CasingLayerOptions;
@@ -92,13 +92,15 @@ export class CasingLayer extends WellboreBaseComponentLayer {
     }
     pts.reverse();
 
-    const triangleSideShoe: Point[] = createNormal(pts, casingDiameter * (offset < 0 ? -1 : 1));
+    const ptNormals = createNormals(pts);
+    const triangleSideShoe: Point[] = offsetPoints(pts, ptNormals, casingDiameter * (offset < 0 ? -1 : 1));
 
     const top = triangleSideShoe[0];
     const bottom = triangleSideShoe[triangleSideShoe.length - 1];
     const middle = triangleSideShoe[triangleSideShoe.length - 2];
 
-    const normalOffset = createNormal([top, middle, bottom], offset);
+    const outlierNormals = createNormals([top, middle, bottom]);
+    const normalOffset = offsetPoints([top, middle, bottom], outlierNormals, offset);
     const outlier = normalOffset[normalOffset.length - 1];
 
     return [top, bottom, outlier];

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -39,7 +39,7 @@ export class CementLayer extends WellboreBaseComponentLayer {
 
     const texture: Texture = this.createTexture();
 
-    polygons.forEach((polygon) => this.drawBigPolygon(polygon, texture));
+    polygons.forEach((polygon) => this.drawRope(polygon, texture, true));
   }
 
   createSimplePolygonPath = (cement: CompiledCement): Point[][] => {

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -70,22 +70,18 @@ export class CementLayer extends WellboreBaseComponentLayer {
     };
 
     const createMiddlePath = (c: CompiledCement): MDPoint[] => {
+      const points = getPath(c.toc, c.boc);
+      const pointsWithNormal = points.map(addNormal);
+      return pointsWithNormal;
+    };
+
+    const getPath = (start: number, end: number): MDPoint[] => {
       const points = [];
       let prevAngle = 10000;
       const allowedAngleDiff = 0.0005;
-      const morePointsForStartAndEndMeters = 10;
-
-      // Take more points for the start and end (default 10 meters, or if not enough cement. Use 1/3 of the cement length)
-      const lastMeters = c.boc - morePointsForStartAndEndMeters > c.toc ? c.boc - morePointsForStartAndEndMeters : c.boc - (c.boc - c.toc) / 3;
-      const firstMeters = c.toc + morePointsForStartAndEndMeters < c.boc ? c.toc + morePointsForStartAndEndMeters : c.toc + (c.boc - c.toc) / 3;
-
-      // Always add first points
-      for (let i = c.toc; i < firstMeters; i += this.options.wellboreBaseComponentIncrement) {
-        points.push(getMdPoint(i));
-      }
 
       // Add distance to points
-      for (let i = firstMeters; i < lastMeters; i += this.options.wellboreBaseComponentIncrement) {
+      for (let i = start; i < end; i += this.options.wellboreBaseComponentIncrement) {
         const point = getMdPoint(i);
         const angle = Math.atan2(point.point.y, point.point.x);
 
@@ -96,15 +92,10 @@ export class CementLayer extends WellboreBaseComponentLayer {
         }
       }
 
-      // Always add last points
-      for (let i = lastMeters; i < c.boc; i += this.options.wellboreBaseComponentIncrement) {
-        points.push(getMdPoint(i));
-      }
-      points.push(getMdPoint(c.boc));
+      // Always add last point
+      points.push(getMdPoint(end));
 
-      const pointsWithNormal = points.map(addNormal);
-
-      return pointsWithNormal;
+      return points;
     };
 
     const getOffset = (offsetItem: any): number => {
@@ -125,7 +116,6 @@ export class CementLayer extends WellboreBaseComponentLayer {
       const points: { left: Point[]; right: Point[] } = { left: [], right: [] };
 
       for (let md = c.toc; md <= c.boc; md += this.options.wellboreBaseComponentIncrement) {
-        // Create normal for sections
         const offsetItem = getClosestRelatedItem(c.intersectingItems, md);
         const start = md;
         md = Math.min(c.boc, offsetItem != null ? offsetItem.end : c.boc); // set next calc MD

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -1,7 +1,7 @@
 import { merge } from 'd3-array';
 import { Point, Texture } from 'pixi.js';
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
-import { CementLayerOptions, OnUpdateEvent, OnRescaleEvent, Cement, Casing, HoleSize, CompiledCement, MDPoint } from '..';
+import { CementLayerOptions, OnUpdateEvent, OnRescaleEvent, Cement, Casing, HoleSize, CompiledCement } from '../interfaces';
 import { cementDiameterChangeDepths, parseCement, calculateCementDiameter } from '../datautils/wellboreItemShapeGenerator';
 import { offsetPoints } from '../utils/vectorUtils';
 
@@ -34,7 +34,10 @@ export class CementLayer extends WellboreBaseComponentLayer {
     }
 
     const { cement, casings, holes } = this.data;
-    this.createCementShapes(cement, casings, holes);
+    const texture: Texture = this.createTexture();
+
+    const paths = this.createCementShapes(cement, casings, holes);
+    paths.forEach((polygon) => this.drawBigPolygon(polygon, texture));
   }
 
   createSimplePolygonPath = (cement: CompiledCement): Point[][] => {
@@ -85,13 +88,12 @@ export class CementLayer extends WellboreBaseComponentLayer {
     return merge(cementPolygonCoords);
   };
 
-  createCementShapes(cement: Cement[], casings: Casing[], holes: HoleSize[]): void {
+  createCementShapes(cement: Cement[], casings: Casing[], holes: HoleSize[]): Point[][] {
     const cementCompiled = cement.map((c: Cement) => parseCement(c, casings, holes));
 
-    const texture: Texture = this.createTexture();
     const paths: Point[][] = merge(cementCompiled.map(this.createSimplePolygonPath));
 
-    paths.map((polygon) => this.drawBigPolygon(polygon, texture));
+    return paths;
   }
 
   createTexture(): Texture {

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -1,3 +1,4 @@
+import { merge } from 'd3-array';
 import { Point, Texture } from 'pixi.js';
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { CementLayerOptions, OnUpdateEvent, OnRescaleEvent, Cement, Casing, HoleSize, CompiledCement, MDPoint } from '..';
@@ -111,7 +112,7 @@ export class CementLayer extends WellboreBaseComponentLayer {
       return offset;
     };
 
-    const createSimplePolygonPath = (c: CompiledCement): Point[] => {
+    const createSimplePolygonPath = (c: CompiledCement): Point[][] => {
       const middle = createMiddlePath(c);
       const points: { left: Point[]; right: Point[] } = { left: [], right: [] };
 
@@ -144,7 +145,10 @@ export class CementLayer extends WellboreBaseComponentLayer {
 
       const sideLeftMiddleR = sideLeftMiddle.map((s) => s.clone()).reverse();
       const rightR = points.right.map((s) => s.clone()).reverse();
-      const cementRectCoords = [...sideLeftMiddleR, ...points.left, ...rightR, ...sideRightMiddle];
+      const cementRectCoords = [
+        [...sideLeftMiddleR, ...points.left],
+        [...rightR, ...sideRightMiddle],
+      ];
 
       // const line = [sideLeftMiddleR[0], sideLeftMiddleR[sideLeftMiddleR.length - 1]];
       // this.drawLine(line, 0xff0000);
@@ -153,7 +157,7 @@ export class CementLayer extends WellboreBaseComponentLayer {
     };
 
     const texture: Texture = this.createTexture();
-    const paths = cementCompiled.map(createSimplePolygonPath);
+    const paths: Point[][] = merge(cementCompiled.map(createSimplePolygonPath));
 
     // const bigSquareBackgroundTest = new Graphics();
     // bigSquareBackgroundTest.beginTextureFill({ texture });

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -2,9 +2,8 @@ import { merge } from 'd3-array';
 import { Point, Texture } from 'pixi.js';
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { CementLayerOptions, OnUpdateEvent, OnRescaleEvent, Cement, Casing, HoleSize, CompiledCement, MDPoint } from '..';
-import { findCasing, findIntersectingItems } from '../datautils/wellboreItemShapeGenerator';
-import { createNormals, offsetPoints } from '../utils/vectorUtils';
-import Vector2 from '@equinor/videx-vector2';
+import { cementDiameterChangeDepths, parseCement, calculateCementDiameter } from '../datautils/wellboreItemShapeGenerator';
+import { offsetPoints } from '../utils/vectorUtils';
 
 export class CementLayer extends WellboreBaseComponentLayer {
   options: CementLayerOptions;
@@ -38,136 +37,64 @@ export class CementLayer extends WellboreBaseComponentLayer {
     this.createCementShapes(cement, casings, holes);
   }
 
-  createCementShapes(cement: Cement[], casings: any, holes: any): any {
-    const parseCement = (cement: Cement, casings: Casing[], holes: HoleSize[]) => {
-      const attachedCasing = findCasing(cement.casingId, casings);
-      const res: CompiledCement = {
-        ...cement,
-        boc: attachedCasing.end,
-        intersectingItems: findIntersectingItems(cement, attachedCasing, casings, holes),
-      };
-      return res;
+  createSimplePolygonPath = (cement: CompiledCement): Point[][] => {
+    const { attachedCasing } = cement;
+    const nonAttachedCasings = cement.intersectingItems.casings;
+    const holes = cement.intersectingItems.holes;
+
+    const innerDiameterInterval = {
+      start: attachedCasing.start,
+      end: attachedCasing.end,
     };
 
+    const outerDiameterIntervals = [...nonAttachedCasings, ...holes].map((d) => ({
+      start: d.start,
+      end: d.end,
+    }));
+
+    const changeDepths = cementDiameterChangeDepths(cement, [innerDiameterInterval, ...outerDiameterIntervals]);
+
+    const diameterAtChangeDepths = changeDepths.map(calculateCementDiameter(attachedCasing, nonAttachedCasings, holes));
+
+    const path = this.getPathWithNormals(
+      cement.toc,
+      cement.boc,
+      diameterAtChangeDepths.map((d) => d.md),
+    );
+
+    let previousDepth = diameterAtChangeDepths.shift();
+    const cementPolygonCoords = diameterAtChangeDepths.map((depth) => {
+      const partMdPoints = path.filter((x) => x.md >= previousDepth.md && x.md <= depth.md);
+
+      const partPoints = partMdPoints.map((s) => s.point);
+      const partPointNormals = partMdPoints.map((s) => s.normal);
+
+      const side1Left = offsetPoints(partPoints, partPointNormals, previousDepth.outerDiameter);
+      const side1Right = offsetPoints(partPoints, partPointNormals, previousDepth.innerDiameter);
+      const side2Left = offsetPoints(partPoints, partPointNormals, -previousDepth.innerDiameter);
+      const side2Right = offsetPoints(partPoints, partPointNormals, -previousDepth.outerDiameter);
+
+      previousDepth = depth;
+
+      return [
+        [...side1Right, ...side1Left.reverse()],
+        [...side2Right, ...side2Left.reverse()],
+      ];
+    });
+
+    return merge(cementPolygonCoords);
+  };
+
+  createCementShapes(cement: Cement[], casings: Casing[], holes: HoleSize[]): void {
     const cementCompiled = cement.map((c: Cement) => parseCement(c, casings, holes));
 
-    const getClosestRelatedItem = (related: (Casing | HoleSize)[], md: number): HoleSize | Casing => {
-      const between = related.filter((r) => r.start <= md && r.end >= md);
-      const sorted = between.sort((a, b) => (a.diameter < b.diameter ? -1 : 1));
-      const result = sorted[0];
-      return result;
-    };
-
-    const getMdPoint = (md: number): MDPoint => {
-      const p = this.referenceSystem.project(md);
-      const point = { point: new Point(p[0], p[1]), md: md };
-      return point;
-    };
-
-    const addNormal = (point: MDPoint): MDPoint => {
-      const normal = this.getNormal(point.md);
-      return { ...point, normal };
-    };
-
-    const createMiddlePath = (c: CompiledCement): MDPoint[] => {
-      const points = getPath(c.toc, c.boc);
-      const pointsWithNormal = points.map(addNormal);
-      return pointsWithNormal;
-    };
-
-    const getPath = (start: number, end: number): MDPoint[] => {
-      const points = [];
-      let prevAngle = 10000;
-      const allowedAngleDiff = 0.0005;
-
-      // Add distance to points
-      for (let i = start; i < end; i += this.options.wellboreBaseComponentIncrement) {
-        const point = getMdPoint(i);
-        const angle = Math.atan2(point.point.y, point.point.x);
-
-        // Reduce number of points on a straight line by angle since last point
-        if (Math.abs(angle - prevAngle) > allowedAngleDiff) {
-          points.push(point);
-          prevAngle = angle;
-        }
-      }
-
-      // Always add last point
-      points.push(getMdPoint(end));
-
-      return points;
-    };
-
-    const getOffset = (offsetItem: any): number => {
-      const offsetDefaultDim = 0.1;
-      const defaultCementWidth = 100; // Default to flow cement outside to seabed to show error in data
-
-      const offsetDimDiff =
-        offsetItem != null && offsetItem.diameter != null && offsetItem.innerDiameter != null
-          ? offsetItem.diameter - offsetItem.innerDiameter
-          : offsetDefaultDim;
-      const offset = offsetItem != null ? offsetItem.diameter - offsetDimDiff : defaultCementWidth;
-
-      return offset;
-    };
-
-    const createSimplePolygonPath = (c: CompiledCement): Point[][] => {
-      const middle = createMiddlePath(c);
-      const points: { left: Point[]; right: Point[] } = { left: [], right: [] };
-
-      for (let md = c.toc; md <= c.boc; md += this.options.wellboreBaseComponentIncrement) {
-        const offsetItem = getClosestRelatedItem(c.intersectingItems, md);
-        const start = md;
-        md = Math.min(c.boc, offsetItem != null ? offsetItem.end : c.boc); // set next calc MD
-
-        // Subtract casing thickness / holesize edge
-        const stop = md;
-        const partMdPoints = middle.filter((x) => x.md >= start && x.md <= stop);
-        const partPoints = partMdPoints.map((s) => s.point);
-        const partPointNormals = partMdPoints.map((s) => s.normal);
-
-        const offset = getOffset(offsetItem);
-
-        const sideLeft = offsetPoints(partPoints, partPointNormals, -offset);
-        const sideRight = offsetPoints(partPoints, partPointNormals, offset);
-        points.left.push(...sideLeft);
-        points.right.push(...sideRight);
-      }
-
-      const wholeMiddlePoints = middle.map((s) => s.point);
-      const wholeMiddlePointNormals = middle.map((s) => s.normal);
-
-      const centerPieceDim = findCasing(c.casingId, this.data.casings).diameter;
-
-      const sideLeftMiddle = offsetPoints(wholeMiddlePoints, wholeMiddlePointNormals, -centerPieceDim);
-      const sideRightMiddle = offsetPoints(wholeMiddlePoints, wholeMiddlePointNormals, +centerPieceDim);
-
-      const sideLeftMiddleR = sideLeftMiddle.map((s) => s.clone()).reverse();
-      const rightR = points.right.map((s) => s.clone()).reverse();
-      const cementRectCoords = [
-        [...sideLeftMiddleR, ...points.left],
-        [...rightR, ...sideRightMiddle],
-      ];
-
-      // const line = [sideLeftMiddleR[0], sideLeftMiddleR[sideLeftMiddleR.length - 1]];
-      // this.drawLine(line, 0xff0000);
-
-      return cementRectCoords;
-    };
-
     const texture: Texture = this.createTexture();
-    const paths: Point[][] = merge(cementCompiled.map(createSimplePolygonPath));
-
-    // const bigSquareBackgroundTest = new Graphics();
-    // bigSquareBackgroundTest.beginTextureFill({ texture });
-    // bigSquareBackgroundTest.drawRect(-1000, -1000, 2000, 2000);
-    // bigSquareBackgroundTest.endFill();
-    // this.ctx.stage.addChild(bigSquareBackgroundTest);
+    const paths: Point[][] = merge(cementCompiled.map(this.createSimplePolygonPath));
 
     paths.map((polygon) => this.drawBigPolygon(polygon, texture));
   }
 
-  createTexture = (): Texture => {
+  createTexture(): Texture {
     const canvas = document.createElement('canvas');
     canvas.width = 150;
     canvas.height = 150;
@@ -191,5 +118,5 @@ export class CementLayer extends WellboreBaseComponentLayer {
     const t = Texture.from(canvas);
 
     return t;
-  };
+  }
 }

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -96,6 +96,11 @@ export class CementLayer extends WellboreBaseComponentLayer {
   }
 
   createTexture(): Texture {
+    const cacheKey = 'cement';
+    if (this._textureCache.hasOwnProperty(cacheKey)) {
+      return this._textureCache[cacheKey];
+    }
+
     const canvas = document.createElement('canvas');
     canvas.width = 150;
     canvas.height = 150;
@@ -117,6 +122,7 @@ export class CementLayer extends WellboreBaseComponentLayer {
     canvasCtx.stroke();
 
     const t = Texture.from(canvas);
+    this._textureCache[cacheKey] = t;
 
     return t;
   }

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -52,9 +52,9 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
       return;
     }
 
-    const { maxTextureDiameterScale, firstColor, secondColor } = this.options;
+    const { maxTextureDiameterScale } = this.options;
 
-    const texture = this.createTexure(holeObject.diameter * maxTextureDiameterScale, firstColor, secondColor);
+    const texture = this.createTexture(holeObject.diameter * maxTextureDiameterScale);
 
     const path = this.getPathWithNormals(holeObject.start, holeObject.end, []);
     const points = path.map((p) => p.point);

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -1,7 +1,6 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { HoleSizeLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, HoleSize } from '..';
-import { Texture } from 'pixi.js';
-import { getEndLines, getRopePolygon } from '../datautils/wellboreItemShapeGenerator';
+import { getEndLines, makeTubularPolygon } from '../datautils/wellboreItemShapeGenerator';
 import { offsetPoints } from '../utils/vectorUtils';
 import { HOLE_OUTLINE } from '../constants';
 
@@ -70,7 +69,7 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
     }
 
     const { top, bottom } = getEndLines(rightPath, leftPath);
-    const polygonCoords = getRopePolygon(leftPath, rightPath);
+    const polygonCoords = makeTubularPolygon(leftPath, rightPath);
 
     this.drawRope(pathPoints, texture);
 

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -1,7 +1,8 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { HoleSizeLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, HoleObjectData, HoleSize } from '..';
 import { Texture } from 'pixi.js';
-import { createOffsetCoords, generateHoleCoords } from '../datautils/wellboreItemShapeGenerator';
+import { generateHoleCoords } from '../datautils/wellboreItemShapeGenerator';
+import { offsetPoints } from '../utils/vectorUtils';
 
 export class HoleSizeLayer extends WellboreBaseComponentLayer {
   options: HoleSizeLayerOptions;
@@ -42,24 +43,30 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
       return;
     }
 
-    const sizes: HoleObjectData[] = data.map((d: HoleSize) => this.generateHoleSizeData(d));
+    // const sizes: HoleObjectData[] = data.map((d: HoleSize) => this.generateHoleSizeData(d));
 
-    const maxDiameter = Math.max(...sizes.map((s: HoleObjectData) => s.data.diameter));
+    const maxDiameter = Math.max(...data.map((s: HoleSize) => s.diameter));
     const texture = this.createTexure(maxDiameter * maxTextureDiameterScale, firstColor, secondColor);
-    sizes
-      .sort((a: any, b: any) => (a.data.diameter <= b.data.diameter ? 1 : -1)) // draw smaller casings and holes inside bigger ones if overlapping
+    data
+      .sort((a: any, b: any) => (a.diameter <= b.diameter ? 1 : -1)) // draw smaller casings and holes inside bigger ones if overlapping
       .map((s: any) => this.drawHoleSize(s, texture));
   }
 
-  drawHoleSize = (holeObject: HoleObjectData, texture: Texture): void => {
-    if (holeObject == null || holeObject.points.length === 0) {
+  drawHoleSize = (holeObject: HoleSize, texture: Texture): void => {
+    if (holeObject == null) {
       return;
     }
 
-    const { maxTextureDiameterScale, firstColor, secondColor, lineColor, topBottomLineColor } = this.options;
-    const { wellBorePathCoords, offsetCoordsLeft, offsetCoordsRight } = createOffsetCoords(holeObject);
+    const path = this.getPathWithNormals(holeObject.start, holeObject.end, []);
 
-    if (wellBorePathCoords.length === 0) {
+    const partPathPoints = path.map((p) => p.point);
+    const normals = path.map((p) => p.normal);
+    const offsetCoordsRight = offsetPoints(partPathPoints, normals, holeObject.diameter);
+    const offsetCoordsLeft = offsetPoints(partPathPoints, normals, -holeObject.diameter);
+
+    const { maxTextureDiameterScale, firstColor, secondColor, lineColor, topBottomLineColor } = this.options;
+
+    if (partPathPoints.length === 0) {
       return;
     }
 
@@ -68,7 +75,7 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
     const mask = this.drawBigPolygon(polygonCoords);
     const casingWallWidth = 1;
 
-    this.createRopeTextureBackground(wellBorePathCoords, texture, mask);
+    this.createRopeTextureBackground(partPathPoints, texture, mask);
 
     this.drawLine(polygonCoords, lineColor, casingWallWidth);
     this.drawLine(top, topBottomLineColor, 1);

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -1,7 +1,7 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
 import { HoleSizeLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, HoleObjectData, HoleSize } from '..';
-import { Texture, Point } from 'pixi.js';
-import { createNormalCoords, generateHoleCoords } from '../datautils/wellboreItemShapeGenerator';
+import { Texture } from 'pixi.js';
+import { createOffsetCoords, generateHoleCoords } from '../datautils/wellboreItemShapeGenerator';
 
 export class HoleSizeLayer extends WellboreBaseComponentLayer {
   options: HoleSizeLayerOptions;
@@ -57,13 +57,13 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
     }
 
     const { maxTextureDiameterScale, firstColor, secondColor, lineColor, topBottomLineColor } = this.options;
-    const { wellBorePathCoords, normalOffsetCoordsDown, normalOffsetCoordsUp } = createNormalCoords(holeObject);
+    const { wellBorePathCoords, offsetCoordsLeft, offsetCoordsRight } = createOffsetCoords(holeObject);
 
     if (wellBorePathCoords.length === 0) {
       return;
     }
 
-    const { top, bottom, left, right } = generateHoleCoords(normalOffsetCoordsUp, normalOffsetCoordsDown);
+    const { top, bottom, left, right } = generateHoleCoords(offsetCoordsRight, offsetCoordsLeft);
     const polygonCoords = [...left, ...right];
     const mask = this.drawBigPolygon(polygonCoords);
     const casingWallWidth = 1;

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -42,19 +42,19 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
       return;
     }
 
-    const { maxTextureDiameterScale, firstColor, secondColor } = this.options;
-
-    const maxDiameter = Math.max(...data.map((s: HoleSize) => s.diameter));
-    const texture = this.createTexure(maxDiameter * maxTextureDiameterScale, firstColor, secondColor);
     data
       .sort((a: HoleSize, b: HoleSize) => (a.diameter <= b.diameter ? 1 : -1)) // draw smaller casings and holes inside bigger ones if overlapping
-      .forEach((hole: HoleSize) => this.drawHoleSize(hole, texture));
+      .forEach((hole: HoleSize) => this.drawHoleSize(hole));
   }
 
-  drawHoleSize = (holeObject: HoleSize, texture: Texture): void => {
+  drawHoleSize = (holeObject: HoleSize): void => {
     if (holeObject == null) {
       return;
     }
+
+    const { maxTextureDiameterScale, firstColor, secondColor } = this.options;
+
+    const texture = this.createTexure(holeObject.diameter * maxTextureDiameterScale, firstColor, secondColor);
 
     const path = this.getPathWithNormals(holeObject.start, holeObject.end, []);
     const points = path.map((p) => p.point);
@@ -71,9 +71,8 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
 
     const { top, bottom } = getEndLines(rightPath, leftPath);
     const polygonCoords = getRopePolygon(leftPath, rightPath);
-    const mask = this.drawBigPolygon(polygonCoords);
 
-    this.createRopeTextureBackground(points, texture, mask);
+    this.drawRope(points, texture);
 
     this.drawLine(polygonCoords, lineColor, HOLE_OUTLINE);
     this.drawLine(top, topBottomLineColor, 1);

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -57,22 +57,22 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
     const texture = this.createTexture(holeObject.diameter * maxTextureDiameterScale);
 
     const path = this.getPathWithNormals(holeObject.start, holeObject.end, []);
-    const points = path.map((p) => p.point);
+    const pathPoints = path.map((p) => p.point);
     const normals = path.map((p) => p.normal);
 
-    const rightPath = offsetPoints(points, normals, holeObject.diameter);
-    const leftPath = offsetPoints(points, normals, -holeObject.diameter);
+    const rightPath = offsetPoints(pathPoints, normals, holeObject.diameter);
+    const leftPath = offsetPoints(pathPoints, normals, -holeObject.diameter);
 
     const { lineColor, topBottomLineColor } = this.options;
 
-    if (points.length === 0) {
+    if (pathPoints.length === 0) {
       return;
     }
 
     const { top, bottom } = getEndLines(rightPath, leftPath);
     const polygonCoords = getRopePolygon(leftPath, rightPath);
 
-    this.drawRope(points, texture);
+    this.drawRope(pathPoints, texture);
 
     this.drawLine(polygonCoords, lineColor, HOLE_OUTLINE);
     this.drawLine(top, topBottomLineColor, 1);

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -68,7 +68,7 @@ export class WellboreBaseComponentLayer extends PixiLayer {
   };
 
   getPathWithNormals = (start: number, end: number, interestPoints: number[]): MDPoint[] => {
-    const points = this.getPathForPoints(start, end, [start, ...interestPoints, end]);
+    const points = this.getPathForPoints(start, end, [start, end, ...interestPoints]);
     const pointsWithNormal = points.map<MDPoint>(this.getNormal);
 
     return pointsWithNormal;
@@ -149,6 +149,6 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     const t = Texture.from(canvas);
     this._textureCache[cacheKey] = t;
 
-    return t;
+    return this._textureCache[cacheKey];
   }
 }

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -1,6 +1,7 @@
 import { Graphics, Texture, Point, SimpleRope } from 'pixi.js';
 import { PixiLayer } from './base/PixiLayer';
 import { HoleSizeLayerOptions, OnUpdateEvent, OnRescaleEvent, MDPoint, HoleObjectData, HoleSize, Casing, OnMountEvent } from '../interfaces';
+import Vector2 from '@equinor/videx-vector2';
 
 const DefaultStaticWellboreBaseComponentIncrement = 0.1;
 
@@ -35,6 +36,12 @@ export class WellboreBaseComponentLayer extends PixiLayer {
 
   // This is overridden by the extended well bore items layers (casing, hole)
   render(event: OnRescaleEvent | OnUpdateEvent): void {}
+
+  getNormal(md: number): Vector2 {
+    const tangent = this.referenceSystem.curtainTangent(md);
+    const normal = new Vector2(tangent[0], tangent[1]).rotate90();
+    return normal;
+  }
 
   drawBigPolygon = (coords: Point[], t?: Texture): Graphics => {
     const polygon = new Graphics();

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -1,7 +1,7 @@
 import { Graphics, Texture, Point, SimpleRope } from 'pixi.js';
 import { merge } from 'd3-array';
 import { PixiLayer } from './base/PixiLayer';
-import { HoleSizeLayerOptions, OnUpdateEvent, OnRescaleEvent, MDPoint, HoleObjectData, HoleSize, Casing, OnMountEvent } from '../interfaces';
+import { HoleSizeLayerOptions, OnUpdateEvent, OnRescaleEvent, MDPoint, OnMountEvent } from '../interfaces';
 import Vector2 from '@equinor/videx-vector2';
 
 const DefaultStaticWellboreBaseComponentIncrement = 0.1;
@@ -26,7 +26,6 @@ export class WellboreBaseComponentLayer extends PixiLayer {
   onUpdate(event: OnUpdateEvent): void {
     super.onUpdate(event);
     this.ctx.stage.removeChildren();
-    //this.render(event);
   }
 
   onRescale(event: OnRescaleEvent): void {
@@ -58,9 +57,8 @@ export class WellboreBaseComponentLayer extends PixiLayer {
   getPath(start: number, end: number): MDPoint[] {
     const points = [];
     let prevAngle = 10000;
-    const allowedAngleDiff = 0.005;
+    const allowedAngleDiff = 0.0005;
 
-    // Add distance to points
     for (let i = start; i < end; i += this.options.wellboreBaseComponentIncrement) {
       const point = this.getMdPoint(i);
       const angle = Math.atan2(point.point.y, point.point.x);
@@ -71,7 +69,6 @@ export class WellboreBaseComponentLayer extends PixiLayer {
         prevAngle = angle;
       }
     }
-
     // Always add last point
     points.push(this.getMdPoint(end));
 
@@ -150,16 +147,4 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     const t = Texture.from(canvas);
     return t;
   };
-
-  // generateHoleSizeData = (data: HoleSize | Casing): HoleObjectData => {
-  //   const points: MDPoint[] = [];
-
-  //   // Add distance to points
-  //   for (let i = data.start; i < data.end; i += this.options.wellboreBaseComponentIncrement) {
-  //     const p = this.referenceSystem.project(i);
-  //     points.push({ point: new Point(p[0], p[1]), md: i });
-  //   }
-
-  //   return { data: { ...data, diameter: data.diameter }, points, hasShoe: data.hasShoe, innerDiameter: data.innerDiameter };
-  // };
 }

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -23,7 +23,10 @@ export class WellboreBaseComponentLayer extends PixiLayer {
 
   onUpdate(event: OnUpdateEvent): void {
     super.onUpdate(event);
-    this.ctx.stage.removeChildren();
+    const children = this.ctx.stage.removeChildren();
+    children.forEach((child) => {
+      child.destroy();
+    });
   }
 
   onRescale(event: OnRescaleEvent): void {

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -8,6 +8,8 @@ import { arrayToPoint } from '../utils/vectorUtils';
 export class WellboreBaseComponentLayer extends PixiLayer {
   options: HoleSizeLayerOptions;
 
+  _textureCache: Record<string, Texture> = {};
+
   constructor(id?: string, options?: HoleSizeLayerOptions) {
     super(id, options);
     this.options = {
@@ -86,7 +88,7 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     return polygon;
   };
 
-  drawRope = (polygon: Point[], texture: Texture, maskTexture: boolean = false): SimpleRope => {
+  drawRope(polygon: Point[], texture: Texture, maskTexture: boolean = false): SimpleRope {
     if (polygon.length === 0) {
       return null;
     }
@@ -105,9 +107,9 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     this.ctx.stage.addChild(rope);
 
     return rope;
-  };
+  }
 
-  drawLine = (coords: Point[], lineColor: number, lineWidth = 1): void => {
+  drawLine(coords: Point[], lineColor: number, lineWidth = 1): void {
     const DRAW_ALIGNMENT_INSIDE = 1;
     const startPoint = coords[0];
     const line = new Graphics();
@@ -115,9 +117,16 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     coords.map((p: Point) => line.lineTo(p.x, p.y));
 
     this.ctx.stage.addChild(line);
-  };
+  }
 
-  createTexure = (maxWidth: number, firstColor: string, secondColor: string, startPctOffset = 0): Texture => {
+  createTexture(maxWidth: number, startPctOffset: number = 0): Texture {
+    const cacheKey = `${maxWidth}X${startPctOffset}`;
+    if (this._textureCache.hasOwnProperty(cacheKey)) {
+      return this._textureCache[cacheKey];
+    }
+
+    const { firstColor, secondColor } = this.options;
+
     const halfWayPct = 0.5;
     const canvas = document.createElement('canvas');
     canvas.width = 300;
@@ -134,6 +143,8 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
 
     const t = Texture.from(canvas);
+    this._textureCache[cacheKey] = t;
+
     return t;
-  };
+  }
 }

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -88,25 +88,29 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     return polygon;
   };
 
-  drawRope(polygon: Point[], texture: Texture, maskTexture: boolean = false): SimpleRope {
-    if (polygon.length === 0) {
+  drawRopeWithMask(path: Point[], maskPolygon: Point[], texture: Texture): void {
+    if (maskPolygon.length === 0 || path.length === 0) {
+      return null;
+    }
+    const rope: SimpleRope = new SimpleRope(texture, path, 1);
+
+    const mask = new Graphics();
+    mask.beginFill(0);
+    mask.drawPolygon(maskPolygon);
+    mask.endFill();
+    this.ctx.stage.addChild(mask);
+    rope.mask = mask;
+
+    this.ctx.stage.addChild(rope);
+  }
+
+  drawRope(path: Point[], texture: Texture): void {
+    if (path.length === 0) {
       return null;
     }
 
-    const rope: SimpleRope = new SimpleRope(texture, polygon, 1);
-
-    if (maskTexture) {
-      const mask = new Graphics();
-      mask.beginFill(0);
-      mask.drawPolygon(polygon);
-      mask.endFill();
-      this.ctx.stage.addChild(mask);
-      rope.mask = mask;
-    }
-
+    const rope: SimpleRope = new SimpleRope(texture, path, 1);
     this.ctx.stage.addChild(rope);
-
-    return rope;
   }
 
   drawLine(coords: Point[], lineColor: number, lineWidth = 1): void {

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -86,13 +86,22 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     return polygon;
   };
 
-  createRopeTextureBackground = (coords: Point[], texture: Texture, mask: Graphics): SimpleRope => {
-    if (coords.length === 0) {
+  drawRope = (polygon: Point[], texture: Texture, maskTexture: boolean = false): SimpleRope => {
+    if (polygon.length === 0) {
       return null;
     }
 
-    const rope: SimpleRope = new SimpleRope(texture, coords);
-    rope.mask = mask;
+    const rope: SimpleRope = new SimpleRope(texture, polygon, 1);
+
+    if (maskTexture) {
+      const mask = new Graphics();
+      mask.beginFill(0);
+      mask.drawPolygon(polygon);
+      mask.endFill();
+      this.ctx.stage.addChild(mask);
+      rope.mask = mask;
+    }
+
     this.ctx.stage.addChild(rope);
 
     return rope;

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -151,15 +151,15 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     return t;
   };
 
-  generateHoleSizeData = (data: HoleSize | Casing): HoleObjectData => {
-    const points: MDPoint[] = [];
+  // generateHoleSizeData = (data: HoleSize | Casing): HoleObjectData => {
+  //   const points: MDPoint[] = [];
 
-    // Add distance to points
-    for (let i = data.start; i < data.end; i += this.options.wellboreBaseComponentIncrement) {
-      const p = this.referenceSystem.project(i);
-      points.push({ point: new Point(p[0], p[1]), md: i });
-    }
+  //   // Add distance to points
+  //   for (let i = data.start; i < data.end; i += this.options.wellboreBaseComponentIncrement) {
+  //     const p = this.referenceSystem.project(i);
+  //     points.push({ point: new Point(p[0], p[1]), md: i });
+  //   }
 
-    return { data: { ...data, diameter: data.diameter }, points, hasShoe: data.hasShoe, innerDiameter: data.innerDiameter };
-  };
+  //   return { data: { ...data, diameter: data.diameter }, points, hasShoe: data.hasShoe, innerDiameter: data.innerDiameter };
+  // };
 }

--- a/src/utils/vectorUtils.ts
+++ b/src/utils/vectorUtils.ts
@@ -49,14 +49,18 @@ export const createNormals = (points: Point[]): Vector2[] => {
   });
 };
 
+export const offsetPoint = (point: Point, vector: Vector2, offset: number): Point => {
+  const p = pointToVector(point);
+  return vectorToPoint(p.add(vector.scale(offset)));
+};
+
 export const offsetPoints = (points: Point[], vectors: Vector2[], offset: number): Point[] => {
   if (points.length !== vectors.length) {
     throw new Error('Number of vectors does not match number of points');
   }
 
   return points.map((point, index) => {
-    const p = pointToVector(point);
-    const n = vectors[index];
-    return vectorToPoint(p.add(n.scale(offset)));
+    const vector = vectors[index];
+    return offsetPoint(point, vector, offset);
   });
 };

--- a/src/utils/vectorUtils.ts
+++ b/src/utils/vectorUtils.ts
@@ -27,23 +27,36 @@ export const convertToUnitVector = (p: Point): Point => {
   return vectorToPoint(pointToVector(p).normalize());
 };
 
-export const createNormal = (coords: Point[], offset: number): Point[] => {
-  const newPoints: Point[] = [];
-  const nextToLastPointIndex = 2;
+export const createNormals = (points: Point[]): Vector2[] => {
+  if (points.length < 2) {
+    return [new Vector2(0)];
+  }
 
-  for (let i = 0; i < coords.length - nextToLastPointIndex; i++) {
-    const p = pointToVector(coords[i]);
-    const n = pointToVector(coords[i + 1])
-      .sub(p)
-      .rotate90()
-      .normalize();
-    newPoints.push(vectorToPoint(p.add(n.scale(offset))));
+  let n: Vector2;
+
+  return points.map((coord, i, list) => {
+    if (i < list.length - 1) {
+      const p = pointToVector(list[i]);
+      const q = pointToVector(list[i + 1]);
+      const np = q.sub(p);
+      const rotate = np.rotate90();
+      n = rotate.normalized();
+      return n;
+    }
+
+    // reuse previous normal for last coord
+    return n;
+  });
+};
+
+export const offsetPoints = (points: Point[], vectors: Vector2[], offset: number): Point[] => {
+  if (points.length !== vectors.length) {
+    throw new Error('Number of vectors does not match number of points');
   }
-  if (coords.length > nextToLastPointIndex) {
-    const p = pointToVector(coords[coords.length - nextToLastPointIndex]);
-    const q = pointToVector(coords[coords.length - nextToLastPointIndex - 1]);
-    const n = p.sub(q).rotate90().normalize();
-    newPoints.push(vectorToPoint(p.add(n.scale(offset))));
-  }
-  return newPoints;
+
+  return points.map((point, index) => {
+    const p = pointToVector(point);
+    const n = vectors[index];
+    return vectorToPoint(p.add(n.scale(offset)));
+  });
 };

--- a/test/vectorUtils.test.ts
+++ b/test/vectorUtils.test.ts
@@ -1,0 +1,65 @@
+import { Point } from 'pixi.js';
+import Vector2 from '@equinor/videx-vector2';
+import { createNormals, offsetPoints } from '../src/utils/vectorUtils';
+
+describe('vectorUtils', () => {
+  describe('createNormals', () => {
+    let points: Point[];
+
+    beforeEach(() => {
+      points = [new Point(0, 0), new Point(1, 1)];
+    });
+
+    it('should return a 0 vector for list of only 1 point', () => {
+      const normals = createNormals([new Point(1, 1)]);
+      expect(normals[0].x).toEqual(0);
+      expect(normals[0].y).toEqual(0);
+      expect(normals[0].magnitude).toEqual(0);
+    });
+
+    it('should create a normal for each point', () => {
+      const normals = createNormals(points);
+      normals.forEach((normal) => {
+        expect(normal instanceof Vector2).toEqual(true);
+      });
+      expect(normals.length).toEqual(points.length);
+    });
+
+    it('should calculate vectors', () => {
+      const normals = createNormals(points);
+      expect(normals[0].x).toBeCloseTo(-0.70710678118, 10);
+      expect(normals[0].y).toBeCloseTo(0.70710678118, 10);
+    });
+
+    it('should be normalized', () => {
+      const normals = createNormals(points);
+      expect(normals[0].magnitude).toBeCloseTo(1, 10);
+    });
+  });
+
+  describe('offsetPoints', () => {
+    let points: Point[];
+    let normals: Vector2[];
+    let newPoints: Point[];
+
+    beforeEach(() => {
+      const vector = new Vector2(-0.70710678118, 0.70710678118);
+      points = [new Point(0, 0), new Point(1, 1), new Point(2, 2)];
+      normals = [vector.clone(), vector.clone(), vector.clone()];
+      newPoints = offsetPoints(points, normals, 1);
+    });
+
+    it('should trow an error if unequal numbers of points and vectors', () => {
+      normals.pop();
+      expect(() => {
+        offsetPoints(points, normals, 1);
+      }).toThrowError();
+    });
+
+    it('should offset each point with the corresponding vector', () => {
+      expect(newPoints[0]).toEqual(new Point(-0.70710678118, 0.70710678118));
+      expect(newPoints[1]).toEqual(new Point(0.29289321881999997, 1.70710678118));
+      expect(newPoints[2]).toEqual(new Point(1.29289321882, 2.7071067811800003));
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "es5",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
- Simplify createNormal and offsetPoints
- Get normals from curve-interpolator
- Add esModuleInterop to tsconfig.json to load Vector2 in Jest tests
- Cache curtain path
- Optimized path generator for hole, casing, and cement
- Simplify shoe render
- Optimize drawing of cement by using pixi.js SimpleRope. This also fixes the texure for cement so it streches/warps along the cement path.
- Optimize drawing of hole and casing by dropping the mask. Create textures of correct width so mask is redundant.
- Remove unneeded interpolation from createOffsetCoords()
- Remove unneeded actualPoints()
- Fix memory leak where Graphics object was not deleted after use. (This is still not optimal. The layers should update the graphics objects and not create new on every frame. Creating new graphics objects on every frame makes for easy memory leaks and unnecessary overhead.)

Closes #268