### PR TITLE
Allow to generate images from PixiLayers

### DIFF
--- a/src/layers/base/PixiLayer.ts
+++ b/src/layers/base/PixiLayer.ts
@@ -31,6 +31,7 @@ export abstract class PixiLayer extends Layer {
         transparent: true,
         clearBeforeRender: true,
         autoResize: true,
+        preserveDrawingBuffer: true,
       };
 
       this.ctx = new Application(pixiOptions);


### PR DESCRIPTION
Simple setting for Pixi that allows to extract the content of a layer as a picture (using https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL).
Note that pictures have to be extracted from individual layers, and composed back together if needed. I haven't found a way to directly extract a single picture out of the entire intersection component (but I admit I haven't tried too hard) 