### PR TITLE
fix: geomodellayer lines distort when increasing zFactor

### DIFF
--- a/src/layers/GeomodelLayer.ts
+++ b/src/layers/GeomodelLayer.ts
@@ -88,7 +88,10 @@ export class GeomodelLayer extends PixiLayer {
   drawSurfaceLine = (s: any): void => {
     const { graphics: g } = this;
     const { data: d } = s;
-    g.lineStyle(s.width, s.color, 1);
+
+    const alignment = 0.5;
+
+    g.lineStyle(s.width, s.color, 1, alignment, true);
     let penDown = false;
     for (let i = 0; i < d.length; i++) {
       if (d[i][1]) {

--- a/src/layers/GeomodelLayerV2.ts
+++ b/src/layers/GeomodelLayerV2.ts
@@ -87,7 +87,10 @@ export class GeomodelLayerV2 extends PixiLayer {
   generateSurfaceLine = (s: any): void => {
     const g = new Graphics();
     const { data: d } = s;
-    g.lineStyle(s.width, s.color, 1);
+
+    const alignment = 0.5;
+    g.lineStyle(s.width, s.color, 1, alignment, true);
+
     let penDown = false;
     for (let i = 0; i < d.length; i++) {
       if (d[i][1]) {


### PR DESCRIPTION
- Render GeoModelLayer lines as lines and not triangle strip.

Fixes #359

Before:
![original-line](https://user-images.githubusercontent.com/705469/92904572-4660c080-f423-11ea-989c-1d244f0b1f20.png)

After:
![zFactor-10](https://user-images.githubusercontent.com/705469/92904595-49f44780-f423-11ea-95ec-89a0b68da552.png)
