### PR TITLE
feat: allow displacement calculated from bottom

### DIFF
--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -48,6 +48,8 @@ export class IntersectionReferenceSystem {
    * @param path (required) array of 3d coordinates: [x, y, z]
    * @param options (optional)
    * @param options.trajectoryAngle (optional) - trajectory angle in degrees, overrides the calculated value
+   * @param options.trajectoryAngleStart (optional) - trajectory angle in degrees from start, overrides the calculated value
+   * @param options.calculateDisplacementFromBottom - (optional) specify if the path is passed from bottom up
    */
   constructor(path: number[][], options?: ReferenceSystemOptions) {
     if (path.length < 1) {
@@ -67,7 +69,7 @@ export class IntersectionReferenceSystem {
 
   private setPath(path: number[][], options: ReferenceSystemOptions = {}): void {
     this.options = options;
-    const { trajectoryAngle } = this.options;
+    const { trajectoryAngle, trajectoryAngleStart } = this.options;
 
     this.path = path;
 
@@ -92,7 +94,14 @@ export class IntersectionReferenceSystem {
     } else {
       this.endVector = IntersectionReferenceSystem.getDirectionVector(this.interpolators.trajectory, 1 - THRESHOLD_DIRECTION_DISTANCE, 1);
     }
-    this.startVector = this.endVector.map((d: number) => d * -1);
+
+    if (isFinite(trajectoryAngleStart)) {
+      const angleInRad = radians(trajectoryAngleStart);
+      const dirVector = new Vector2(Math.cos(angleInRad), Math.sin(angleInRad)).toArray();
+      this.startVector = dirVector;
+    } else {
+      this.startVector = IntersectionReferenceSystem.getDirectionVector(this.interpolators.trajectory, 0 + THRESHOLD_DIRECTION_DISTANCE, 0);
+    }
 
     this._curtainPathCache = undefined;
   }
@@ -102,7 +111,14 @@ export class IntersectionReferenceSystem {
    */
   project(length: number): number[] {
     const { curtain } = this.interpolators;
-    const l = (length - this._offset) / this.length;
+    const { calculateDisplacementFromBottom } = this.options;
+
+    let l: number;
+    if (calculateDisplacementFromBottom) {
+      l = (this.length - (length - this._offset)) / this.length;
+    } else {
+      l = (length - this._offset) / this.length;
+    }
     const t = clamp(l, 0, 1);
     const p = curtain.getPointAt(t);
     return p;
@@ -150,13 +166,17 @@ export class IntersectionReferenceSystem {
    * Map a displacement back to length along the curve
    */
   unproject(displacement: number): number {
-    if (displacement < 0) {
-      return displacement;
+    const { calculateDisplacementFromBottom } = this.options;
+    const displacementFromStart = calculateDisplacementFromBottom ? this.displacement - displacement : displacement;
+
+    if (displacementFromStart < 0) {
+      return displacementFromStart;
     }
-    if (displacement > this.displacement) {
-      return this.length + (displacement - this.displacement);
+    if (displacementFromStart > this.displacement) {
+      return this.length + (displacementFromStart - this.displacement);
     }
-    const ls = this.interpolators.curtain.lookupPositions(displacement, 0, 1);
+
+    const ls = this.interpolators.curtain.lookupPositions(displacementFromStart, 0, 1);
     if (ls && ls.length) {
       return ls[0] * this.length + this._offset;
     }

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -278,8 +278,16 @@ export class IntersectionReferenceSystem {
 
     const totalLength = this.displacement + extensionStart + extensionEnd;
     const preSteps = Math.floor((extensionStart / totalLength) * steps);
-    const curveSteps = Math.max(Math.ceil((this.displacement / totalLength) * steps), 1);
-    const postSteps = steps - curveSteps - preSteps;
+    let curveSteps = Math.max(Math.ceil((this.displacement / totalLength) * steps), 1);
+
+    // The curve interpolator returns steps + 1 number of points
+    // Subtract the extra point from curveSteps if enough points
+    const extraCurveStep = 1;
+    if (curveSteps > 1) {
+      curveSteps -= extraCurveStep;
+    }
+
+    const postSteps = steps - (curveSteps + extraCurveStep) - preSteps;
 
     const points = [];
 
@@ -297,8 +305,8 @@ export class IntersectionReferenceSystem {
     const refEnd = new Vector2(this.interpolators.trajectory.getPointAt(1.0));
     const endVec = new Vector2(this.endVector);
     const postStep = extensionEnd / postSteps;
-    for (let i = 1; i < postSteps; i++) {
-      const f = i * postStep;
+    for (let i = 0; i < postSteps; i++) {
+      const f = (i + 1) * postStep;
       const point = refEnd.add(endVec.scale(f));
       points.push(point.toArray());
     }

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -107,10 +107,8 @@ export class IntersectionReferenceSystem {
     const { curtain } = this.interpolators;
     const { calculateDisplacementFromBottom } = this.options;
 
-    let l = (length - this._offset) / this.length;
-    if (calculateDisplacementFromBottom) {
-      l = 1 - l;
-    }
+    const normalizedLength = (length - this._offset) / this.length;
+    const l = calculateDisplacementFromBottom ? 1 - normalizedLength : normalizedLength;
 
     const t = clamp(l, 0, 1);
     const p = curtain.getPointAt(t);

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -107,12 +107,11 @@ export class IntersectionReferenceSystem {
     const { curtain } = this.interpolators;
     const { calculateDisplacementFromBottom } = this.options;
 
-    let l: number;
+    let l = (length - this._offset) / this.length;
     if (calculateDisplacementFromBottom) {
-      l = (this.length - (length - this._offset)) / this.length;
-    } else {
-      l = (length - this._offset) / this.length;
+      l = 1 - l;
     }
+
     const t = clamp(l, 0, 1);
     const p = curtain.getPointAt(t);
     return p;

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -269,16 +269,8 @@ export class IntersectionReferenceSystem {
 
     const totalLength = this.displacement + extensionStart + extensionEnd;
     const preSteps = Math.floor((extensionStart / totalLength) * steps);
-    let curveSteps = Math.max(Math.ceil((this.displacement / totalLength) * steps), 1);
-
-    // The curve interpolator returns steps + 1 number of points
-    // Subtract the extra point from curveSteps if enough points
-    const extraCurveStep = 1;
-    if (curveSteps > 1) {
-      curveSteps -= extraCurveStep;
-    }
-
-    const postSteps = steps - (curveSteps + extraCurveStep) - preSteps;
+    const curveSteps = Math.max(Math.ceil((this.displacement / totalLength) * steps), 1);
+    const postSteps = steps - curveSteps - preSteps;
 
     const points = [];
 
@@ -296,8 +288,8 @@ export class IntersectionReferenceSystem {
     const refEnd = new Vector2(this.interpolators.trajectory.getPointAt(1.0));
     const endVec = new Vector2(this.endVector);
     const postStep = extensionEnd / postSteps;
-    for (let i = 0; i < postSteps; i++) {
-      const f = (i + 1) * postStep;
+    for (let i = 1; i < postSteps; i++) {
+      const f = i * postStep;
       const point = refEnd.add(endVec.scale(f));
       points.push(point.toArray());
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -172,7 +172,6 @@ export interface Trajectory {
 
 export interface ReferenceSystemOptions {
   trajectoryAngle?: number;
-  trajectoryAngleStart?: number;
   calculateDisplacementFromBottom?: boolean;
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -172,6 +172,8 @@ export interface Trajectory {
 
 export interface ReferenceSystemOptions {
   trajectoryAngle?: number;
+  trajectoryAngleStart?: number;
+  calculateDisplacementFromBottom?: boolean;
 }
 
 export type BoundingBox = {

--- a/test/reference-system.test.ts
+++ b/test/reference-system.test.ts
@@ -118,7 +118,7 @@ describe('Reference system', () => {
       [30, 40, 100],
       [30, 40, 7000],
     ];
-    const options = { trajectoryAngle: 45.0, trajectoryAngleStart: 45.0 + 180 };
+    const options = { trajectoryAngle: 45.0 };
     const irs = new IntersectionReferenceSystem(verticalPosLog, options);
 
     const trajectory = irs.getExtendedTrajectory(100, 1500.0, 1500.0);

--- a/test/reference-system.test.ts
+++ b/test/reference-system.test.ts
@@ -1,3 +1,4 @@
+import { degrees } from '@equinor/videx-math';
 import { IntersectionReferenceSystem } from '../src';
 
 const wp = [
@@ -95,6 +96,8 @@ describe('Reference system', () => {
       lastPoint = point;
     }
   });
+  */
+
   it('should have correct length on extension', () => {
     const trajectory = rs.getExtendedTrajectory(100, 500.0, 500.0);
     const startExtend = dist(trajectory.points[0], rs.interpolators.trajectory.getPointAt(0.0));
@@ -102,7 +105,6 @@ describe('Reference system', () => {
     expect(startExtend).toBeCloseTo(500.0);
     expect(endExtend).toBeCloseTo(500.0);
   });
-*/
   it('should throw error when parameters are negative', () => {
     expect(() => {
       const trajectory = rs.getExtendedTrajectory(100, -50.0, 500.0);
@@ -111,13 +113,12 @@ describe('Reference system', () => {
       const trajectory = rs.getExtendedTrajectory(100, 50.0, -500.0);
     }).toThrow('Invalid parameter, getExtendedTrajectory() must be called with a valid and positive extensionEnd parameter');
   });
-  /*
   it('should work for vertical wellbore', () => {
     const verticalPosLog = [
       [30, 40, 100],
       [30, 40, 7000],
     ];
-    const options = {trajectoryAngle: 45.0};
+    const options = { trajectoryAngle: 45.0, trajectoryAngleStart: 45.0 + 180 };
     const irs = new IntersectionReferenceSystem(verticalPosLog, options);
 
     const trajectory = irs.getExtendedTrajectory(100, 1500.0, 1500.0);
@@ -128,7 +129,6 @@ describe('Reference system', () => {
     expect(startExtend).toBeCloseTo(1500.0);
     expect(endExtend).toBeCloseTo(1500.0);
     const angle = Math.atan((trajectory.points[99][0] - trajectory.points[0][0]) / (trajectory.points[99][1] - trajectory.points[0][1]));
-    expect(endExtend).toBeCloseTo(45.0);
+    expect(degrees(angle)).toBeCloseTo(45.0);
   });
-  */
 });

--- a/test/reference-system.test.ts
+++ b/test/reference-system.test.ts
@@ -1,4 +1,3 @@
-import { degrees } from '@equinor/videx-math';
 import { IntersectionReferenceSystem } from '../src';
 
 const wp = [
@@ -96,8 +95,6 @@ describe('Reference system', () => {
       lastPoint = point;
     }
   });
-  */
-
   it('should have correct length on extension', () => {
     const trajectory = rs.getExtendedTrajectory(100, 500.0, 500.0);
     const startExtend = dist(trajectory.points[0], rs.interpolators.trajectory.getPointAt(0.0));
@@ -105,6 +102,7 @@ describe('Reference system', () => {
     expect(startExtend).toBeCloseTo(500.0);
     expect(endExtend).toBeCloseTo(500.0);
   });
+*/
   it('should throw error when parameters are negative', () => {
     expect(() => {
       const trajectory = rs.getExtendedTrajectory(100, -50.0, 500.0);
@@ -113,12 +111,13 @@ describe('Reference system', () => {
       const trajectory = rs.getExtendedTrajectory(100, 50.0, -500.0);
     }).toThrow('Invalid parameter, getExtendedTrajectory() must be called with a valid and positive extensionEnd parameter');
   });
+  /*
   it('should work for vertical wellbore', () => {
     const verticalPosLog = [
       [30, 40, 100],
       [30, 40, 7000],
     ];
-    const options = { trajectoryAngle: 45.0 };
+    const options = {trajectoryAngle: 45.0};
     const irs = new IntersectionReferenceSystem(verticalPosLog, options);
 
     const trajectory = irs.getExtendedTrajectory(100, 1500.0, 1500.0);
@@ -129,6 +128,7 @@ describe('Reference system', () => {
     expect(startExtend).toBeCloseTo(1500.0);
     expect(endExtend).toBeCloseTo(1500.0);
     const angle = Math.atan((trajectory.points[99][0] - trajectory.points[0][0]) / (trajectory.points[99][1] - trajectory.points[0][1]));
-    expect(degrees(angle)).toBeCloseTo(45.0);
+    expect(endExtend).toBeCloseTo(45.0);
   });
+  */
 });


### PR DESCRIPTION
This will let the IntersectionReferenceSystem work with position log in both direction (top to bottom and bottom to top). 

The changes touches the MD to displacement calculations and the reverse calculation.
And we have added the possibility to provide a trajectoryAngleStart so both ends of the poslog can get a preset angel.

The changes to IntersectionReferenceSystem.startVector should be reviewed closely by the Videx team as the REP application is using getExtendedTrajectory() that depends on this vector.
