### PR TITLE
fix: print SurfaceLine label, not id

### DIFF
--- a/src/datautils/surfacedata.ts
+++ b/src/datautils/surfacedata.ts
@@ -70,6 +70,7 @@ function generateGroupAreas(groups: any, trajectory: number[][]): any {
     const next: any = i + 1 < groups.length ? groups[i + 1] : null;
     return {
       id: g.id,
+      label: g.label,
       color: convertColor(g.color),
       data: trajectory.map((p: any, j: any) => [p[0], g.top[j], next ? next.top[j] : null]),
     };

--- a/src/datautils/surfacedata.ts
+++ b/src/datautils/surfacedata.ts
@@ -93,6 +93,7 @@ function mapGroups(stratGroups: any, surfaceAreas: SurfaceArea[][]): any {
       const top = surface[0];
       return {
         id: g.name,
+        label: g.name,
         color: unassignedColorScale(i),
         top: top.data.map((d: number[]) => d[1]),
       };

--- a/src/layers/GeomodelLabelsLayer.ts
+++ b/src/layers/GeomodelLabelsLayer.ts
@@ -323,7 +323,7 @@ export class GeomodelLabelsLayer extends CanvasLayer {
     ctx.rotate(textDir);
     ctx.fillStyle = this.colorToCSSColor(s.color);
     ctx.textBaseline = 'middle';
-    ctx.fillText(s.id, 0, 0);
+    ctx.fillText(s.label, 0, 0);
 
     ctx.restore();
   };


### PR DESCRIPTION
@tormy pointed out that id was used instead of label for GeomodelLabelsLayer drawLineLabel() and drawAreaLabel(). drawAreaLabel() was already fixed though in recent commit.