### PR TITLE
Fix onUnmount on PixiLayers

### DIFF
--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -1,5 +1,5 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
-import { CasingLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, Casing } from '..';
+import { CasingLayerOptions, OnUpdateEvent, OnRescaleEvent, Casing } from '..';
 import { Point, RENDERER_TYPE } from 'pixi.js';
 import { makeTubularPolygon } from '../datautils/wellboreItemShapeGenerator';
 import { createNormals, offsetPoint, offsetPoints } from '../utils/vectorUtils';
@@ -16,10 +16,6 @@ export class CasingLayer extends WellboreBaseComponentLayer {
       ...options,
     };
     this.render = this.render.bind(this);
-  }
-
-  onMount(event: OnMountEvent): void {
-    super.onMount(event);
   }
 
   onUpdate(event: OnUpdateEvent): void {

--- a/src/layers/CompletionLayer.ts
+++ b/src/layers/CompletionLayer.ts
@@ -1,7 +1,7 @@
 import Vector2 from '@equinor/videx-vector2';
 import { Graphics } from 'pixi.js';
 import { PixiLayer } from './base/PixiLayer';
-import { OnMountEvent, OnUpdateEvent, OnRescaleEvent } from '..';
+import { OnUpdateEvent } from '..';
 import { CompletionLayerOptions } from '../interfaces';
 
 interface CompletionItem {}
@@ -13,10 +13,6 @@ export class CompletionLayer extends PixiLayer {
       ...options,
     };
     this.render = this.render.bind(this);
-  }
-
-  onMount(event: OnMountEvent): void {
-    super.onMount(event);
   }
 
   onUpdate(event: OnUpdateEvent): void {

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -1,5 +1,5 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
-import { HoleSizeLayerOptions, OnMountEvent, OnUpdateEvent, OnRescaleEvent, HoleSize } from '..';
+import { HoleSizeLayerOptions, OnUpdateEvent, OnRescaleEvent, HoleSize } from '..';
 import { makeTubularPolygon } from '../datautils/wellboreItemShapeGenerator';
 import { createNormals, offsetPoints } from '../utils/vectorUtils';
 import { HOLE_OUTLINE } from '../constants';
@@ -20,10 +20,6 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
       ...options,
     };
     this.render = this.render.bind(this);
-  }
-
-  onMount(event: OnMountEvent): void {
-    super.onMount(event);
   }
 
   onUpdate(event: OnUpdateEvent): void {

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -1,7 +1,7 @@
-import { Graphics, Texture, Point, SimpleRope, RENDERER_TYPE } from 'pixi.js';
+import { Graphics, Texture, Point, SimpleRope } from 'pixi.js';
 import { merge } from 'd3-array';
 import { PixiLayer } from './base/PixiLayer';
-import { HoleSizeLayerOptions, OnUpdateEvent, OnRescaleEvent, OnMountEvent, WellComponentBaseOptions, MDPoint } from '../interfaces';
+import { HoleSizeLayerOptions, OnUpdateEvent, OnRescaleEvent, WellComponentBaseOptions, MDPoint, OnUnmountEvent } from '../interfaces';
 import { convertColor } from '../utils/color';
 
 const createGradientFill = (
@@ -35,8 +35,10 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     this.render = this.render.bind(this);
   }
 
-  onMount(event: OnMountEvent): void {
-    super.onMount(event);
+  onUnmount(event?: OnUnmountEvent): void {
+    super.onUnmount(event);
+    this._textureCache = null;
+    this.rescaleEvent = null;
   }
 
   onUpdate(event: OnUpdateEvent): void {
@@ -202,9 +204,5 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     this._textureCache[cacheKey] = t;
 
     return this._textureCache[cacheKey];
-  }
-
-  get renderType(): RENDERER_TYPE {
-    return this.ctx.renderer.type;
   }
 }


### PR DESCRIPTION
Browser gave a warning about too many WebGL contexts opened when creating the component a few times.

It's uncertain wether the WEBGL_lose_context trick fixes or just hides the issue, but testing to recreate the layers several hundred times did not reveal any memory leak.