### PR TITLE
feat: destroy method on Controller

### DIFF
--- a/.storybook/src/utils/elements.ts
+++ b/.storybook/src/utils/elements.ts
@@ -11,7 +11,7 @@ export const createRootContainer = (width: number) => {
 
 export const createLayerContainer = (width: number, height: number) => {
   const container = document.createElement('div');
-  container.className = 'layer-container';
+  container.className = 'story-layer-container';
   container.setAttribute('style', `height: ${height}px; width: ${width}px;background-color: #eee;`);
   container.setAttribute('height', `${height}`);
   container.setAttribute('width', `${width}`);

--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -94,16 +94,27 @@ export class LayerManager {
   }
 
   /**
-   * Remove layer from manager, and unmounts it
+   * Remove and unmount layer from manager
    * @param layerId name of layer
    */
   removeLayer(layerId: string): LayerManager {
-    const idx = this.layers.findIndex((l) => l.id === layerId);
-    if (idx !== -1) {
-      this.layers[idx].onUnmount();
-      this.layers.splice(idx, 1);
+    const layer = this.layers.find((l) => l.id === layerId);
+    if (layer) {
+      layer.onUnmount();
+      this.layers = this.layers.filter((l) => l.id !== layerId);
     }
 
+    return this;
+  }
+
+  /**
+   * Remove and unmount all layers from manager
+   */
+  removeAllLayers(): LayerManager {
+    const { layers } = this;
+    layers.forEach((layer) => {
+      this.removeLayer(layer.id);
+    });
     return this;
   }
 
@@ -227,6 +238,20 @@ export class LayerManager {
 
   setMinZoomLevel(zoomlevel: number): LayerManager {
     this._zoomPanHandler.setMinZoomLevel(zoomlevel);
+    return this;
+  }
+
+  destroy(): LayerManager {
+    this.clearAllData(true);
+    this.removeAllLayers();
+    this.layerContainer.remove();
+    this.layerContainer = undefined;
+    this.container = undefined;
+    this.layers = undefined;
+    this._zoomPanHandler = undefined;
+    this._axis = undefined;
+    this._svgContainer = undefined;
+
     return this;
   }
 

--- a/src/control/MainController.ts
+++ b/src/control/MainController.ts
@@ -86,11 +86,19 @@ export class Controller {
   }
 
   /**
-   * Remove layer from list
+   * Remove and unmount layer from list
    * @param layerId string id
    */
   removeLayer(layerId: string): Controller {
     this.layerManager.removeLayer(layerId);
+    return this;
+  }
+
+  /**
+   * Remove and unmount all layers from list
+   */
+  removeAllLayers(): Controller {
+    this.layerManager.removeAllLayers();
     return this;
   }
 
@@ -240,6 +248,19 @@ export class Controller {
    */
   setMinZoomLevel(zoomlevel: number): Controller {
     this.zoomPanHandler.setMinZoomLevel(zoomlevel);
+    return this;
+  }
+
+  /**
+   * Destroy Controller
+   * Convenience method for removing from DOM and clearing references
+   */
+  destroy(): Controller {
+    this.layerManager.destroy();
+    this._overlay.destroy();
+    this._referenceSystem = undefined;
+    this.layerManager = undefined;
+    this._overlay = undefined;
     return this;
   }
 

--- a/src/control/overlay.ts
+++ b/src/control/overlay.ts
@@ -109,6 +109,10 @@ class Overlay {
   setZIndex(zIndex: number): void {
     this.elm.style('z-index', zIndex);
   }
+
+  destroy(): void {
+    this.source.remove();
+  }
 }
 
 const overlay = (caller: any, container: HTMLElement): Overlay => new Overlay(caller, container);

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -57,7 +57,7 @@ export class CasingLayer extends WellboreBaseComponentLayer {
     const casingWallWidth = Math.abs(casing.diameter - casing.innerDiameter);
 
     // Pixi.js-legacy handles SimpleRope and advanced render methods poorly
-    if (this.renderType === RENDERER_TYPE.CANVAS) {
+    if (this.renderType() === RENDERER_TYPE.CANVAS) {
       this.drawBigPolygon(polygon, solidColor);
     } else {
       this.drawRope(

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -48,7 +48,7 @@ export class CementLayer extends WellboreBaseComponentLayer {
     const texture: Texture = this.createTexture();
 
     cementShapes.forEach((cementShape: CementShape) => {
-      if (this.renderType === RENDERER_TYPE.CANVAS) {
+      if (this.renderType() === RENDERER_TYPE.CANVAS) {
         this.drawBigTexturedPolygon(cementShape.leftPolygon, texture);
         this.drawBigTexturedPolygon(cementShape.rightPolygon, texture);
       } else {

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -62,7 +62,7 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
     }
 
     const polygonCoords = makeTubularPolygon(leftPath, rightPath);
-    if (this.renderType === RENDERER_TYPE.CANVAS) {
+    if (this.renderType() === RENDERER_TYPE.CANVAS) {
       this.drawBigPolygon(polygonCoords, firstColor);
     } else {
       this.drawRope(

--- a/src/layers/base/PixiLayer.ts
+++ b/src/layers/base/PixiLayer.ts
@@ -41,7 +41,8 @@ export abstract class PixiLayer extends Layer {
   onUnmount(event?: OnUnmountEvent): void {
     super.onUnmount(event);
 
-    const { renderType } = this;
+    // Get renderType and clContext before we destroy the renderer
+    const renderType = this.renderType();
     const glContext = this.ctx.renderer?.gl;
 
     this.ctx.stop();
@@ -115,7 +116,7 @@ export abstract class PixiLayer extends Layer {
     }
   }
 
-  get renderType(): RENDERER_TYPE {
+  renderType(): RENDERER_TYPE {
     return this.ctx.renderer.type;
   }
 }

--- a/src/layers/base/PixiLayer.ts
+++ b/src/layers/base/PixiLayer.ts
@@ -41,6 +41,7 @@ export abstract class PixiLayer extends Layer {
   onUnmount(event?: OnUnmountEvent): void {
     super.onUnmount(event);
 
+    const { renderType } = this;
     const glContext = this.ctx.renderer?.gl;
 
     this.ctx.stop();
@@ -52,7 +53,7 @@ export abstract class PixiLayer extends Layer {
      *
      * Cleaning up our self since it still seems to work and fix issue with lingering contexts
      */
-    if (this.renderType === RENDERER_TYPE.WEBGL) {
+    if (renderType === RENDERER_TYPE.WEBGL) {
       glContext?.getExtension('WEBGL_lose_context')?.loseContext();
     }
 


### PR DESCRIPTION
- fix bug in PixiLayer onUnmount
- change class name in createLayerContainer, class name was also used in LayerManager
- implement destroy method on Controller to remove overlay and layers from DOM, unmount layers and unset references

Destroy is implemented to help applications safely clean up after use.