### PR TITLE
fix: use before assign of reference system

### DIFF
--- a/src/layers/CalloutCanvasLayer.ts
+++ b/src/layers/CalloutCanvasLayer.ts
@@ -89,14 +89,15 @@ export class CalloutCanvasLayer extends CanvasLayer {
     }
 
     const { xScale, yScale, xBounds } = this.rescaleEvent;
-    const { data, ctx, groupFilter } = this;
-    const { calculateDisplacementFromBottom } = this.options.referenceSystem.options;
-    const isLeftToRight = calculateDisplacementFromBottom ? xBounds[0] < xBounds[1] : xBounds[0] > xBounds[1];
-    const scale = 0;
 
     const fontSize = calcSize(this.fontSizeFactor, this.minFontSize, this.maxFontSize, xScale);
 
     if (!isPanning || !this.callouts) {
+      const { data, ctx, groupFilter } = this;
+      const { calculateDisplacementFromBottom } = this.referenceSystem.options;
+      const isLeftToRight = calculateDisplacementFromBottom ? xBounds[0] < xBounds[1] : xBounds[0] > xBounds[1];
+      const scale = 0;
+
       ctx.font = `bold ${fontSize}px arial`;
       const filtered = data.filter((d: Annotation) => !groupFilter || groupFilter.includes(d.group));
       const offset = calcSize(this.offsetFactor, this.offsetMin, this.offsetMax, xScale);

--- a/src/layers/CalloutCanvasLayer.ts
+++ b/src/layers/CalloutCanvasLayer.ts
@@ -84,7 +84,7 @@ export class CalloutCanvasLayer extends CanvasLayer {
   render(isPanning = false): void {
     this.clearCanvas();
 
-    if (!this.data || !this.rescaleEvent) {
+    if (!this.data || !this.rescaleEvent || !this.referenceSystem) {
       return;
     }
 

--- a/test/callout-canvas-layer.test.ts
+++ b/test/callout-canvas-layer.test.ts
@@ -1,0 +1,102 @@
+import { scaleLinear } from 'd3-scale';
+import { zoomIdentity } from 'd3-zoom';
+import { CanvasRenderingContext2DEvent } from 'jest-canvas-mock';
+import { CalloutCanvasLayer, IntersectionReferenceSystem } from '../src/index';
+
+describe('CalloutCanvasLayer', () => {
+  let elm: HTMLElement;
+  const wp = [
+    [30, 40, 4],
+    [40, 70, 6],
+    [45, 100, 8],
+    [50, 110, 10],
+  ];
+
+  beforeEach(() => {
+    elm = document.createElement('div');
+  });
+  afterEach(() => {
+    elm.remove();
+  });
+  describe('when setting reference system', () => {
+    const data = [
+      {
+        title: 'Seabed',
+        group: 'ref-picks',
+        label: '91.1 m RKB',
+        color: 'rgba(0,0,0,0.8)',
+        md: 91.1,
+      },
+    ];
+    const xBounds = [0, 1000] as [number, number];
+    const yBounds = [0, 1000] as [number, number];
+    const layerEvent = {
+      xBounds,
+      yBounds,
+      zFactor: 1,
+      viewportRatio: 1,
+      xRatio: 1,
+      yRatio: 1,
+      width: 1,
+      height: 1,
+      transform: zoomIdentity,
+      xScale: scaleLinear().domain(xBounds).range([0, 1]),
+      yScale: scaleLinear().domain(yBounds).range([0, 1]),
+    };
+
+    it('should render when reference system is set in constructor', () => {
+      // Arrange
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      const layer = new CalloutCanvasLayer('calloutcanvaslayer', { referenceSystem });
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      layer.ctx.__clearEvents();
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      const events: CanvasRenderingContext2DEvent[] = layer.ctx.__getEvents();
+      const fillTextCalls = events.filter((call: any) => call.type === 'fillText');
+      expect(fillTextCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should render when reference system is set after constructor', () => {
+      // Arrange
+      const layer = new CalloutCanvasLayer('calloutcanvaslayer', {});
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      layer.referenceSystem = referenceSystem;
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      layer.ctx.__clearEvents();
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      const events: CanvasRenderingContext2DEvent[] = layer.ctx.__getEvents();
+      const fillTextCalls = events.filter((call: any) => call.type === 'fillText');
+      expect(fillTextCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should not throw exception when setting data without reference system', () => {
+      // Arrange
+      const layer = new CalloutCanvasLayer('calloutcanvaslayer', {});
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      layer.ctx.__clearEvents();
+
+      // Act
+      // Assert
+      expect(() => {
+        layer.data = data;
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Fixes error when setting data before reference system on CalloutCanvasLayer.


I think we have some similar bugs in the Pixi.js layers. I will look at that and make similar fixes and tests if so.