### PR TITLE
fix: use referencesystem before assign in WellboreBaseComponentLayers

### DIFF
--- a/__mocks__/pixi.js.ts
+++ b/__mocks__/pixi.js.ts
@@ -1,0 +1,17 @@
+import { RENDERER_TYPE } from 'pixi.js';
+
+const pixi = jest.requireActual('pixi.js');
+
+module.exports = {
+  ...pixi,
+  Application: class Application {
+    view = document.createElement('div');
+    renderer = { type: RENDERER_TYPE.WEBGL };
+    stage = {
+      addChild: jest.fn(),
+      removeChildren: jest.fn((): any[] => []),
+      position: { set: jest.fn() },
+      scale: { set: jest.fn() },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "setupFiles": [
       "jest-canvas-mock"
     ],
-    "testRegex": "/test/.*",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -27,7 +27,7 @@ export class CasingLayer extends WellboreBaseComponentLayer {
   render(event: OnRescaleEvent | OnUpdateEvent): void {
     const { data }: { data: Casing[] } = this;
 
-    if (data == null || !this.rescaleEvent) {
+    if (!data || !this.rescaleEvent || !this.referenceSystem) {
       return;
     }
 

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -38,7 +38,7 @@ export class CementLayer extends WellboreBaseComponentLayer {
   }
 
   render(event: OnRescaleEvent | OnUpdateEvent): void {
-    if (this.data == null || !this.rescaleEvent) {
+    if (!this.data || !this.rescaleEvent || !this.referenceSystem) {
       return;
     }
 

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -30,7 +30,7 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
   render(event: OnRescaleEvent | OnUpdateEvent): void {
     const { data } = this;
 
-    if (data == null || !this.rescaleEvent) {
+    if (!data || !this.rescaleEvent || !this.referenceSystem) {
       return;
     }
 

--- a/test/callout-canvas-layer.test.ts
+++ b/test/callout-canvas-layer.test.ts
@@ -1,7 +1,6 @@
-import { scaleLinear } from 'd3-scale';
-import { zoomIdentity } from 'd3-zoom';
 import { CanvasRenderingContext2DEvent } from 'jest-canvas-mock';
 import { CalloutCanvasLayer, IntersectionReferenceSystem } from '../src/index';
+import { rescaleEventStub } from './test-helpers';
 
 describe('CalloutCanvasLayer', () => {
   let elm: HTMLElement;
@@ -28,21 +27,6 @@ describe('CalloutCanvasLayer', () => {
         md: 91.1,
       },
     ];
-    const xBounds = [0, 1000] as [number, number];
-    const yBounds = [0, 1000] as [number, number];
-    const layerEvent = {
-      xBounds,
-      yBounds,
-      zFactor: 1,
-      viewportRatio: 1,
-      xRatio: 1,
-      yRatio: 1,
-      width: 1,
-      height: 1,
-      transform: zoomIdentity,
-      xScale: scaleLinear().domain(xBounds).range([0, 1]),
-      yScale: scaleLinear().domain(yBounds).range([0, 1]),
-    };
 
     it('should render when reference system is set in constructor', () => {
       // Arrange
@@ -50,7 +34,7 @@ describe('CalloutCanvasLayer', () => {
       const layer = new CalloutCanvasLayer('calloutcanvaslayer', { referenceSystem });
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       layer.ctx.__clearEvents();
 
@@ -70,7 +54,7 @@ describe('CalloutCanvasLayer', () => {
       layer.referenceSystem = referenceSystem;
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       layer.ctx.__clearEvents();
 
@@ -88,7 +72,7 @@ describe('CalloutCanvasLayer', () => {
       const layer = new CalloutCanvasLayer('calloutcanvaslayer', {});
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       layer.ctx.__clearEvents();
 

--- a/test/casing-layer.test.ts
+++ b/test/casing-layer.test.ts
@@ -1,0 +1,83 @@
+import { scaleLinear } from 'd3-scale';
+import { zoomIdentity } from 'd3-zoom';
+import { CasingLayer, IntersectionReferenceSystem } from '../src/index';
+
+describe('CasingLayer', () => {
+  let elm: HTMLElement;
+  const wp = [
+    [30, 40, 0],
+    [40, 70, 600],
+    [45, 100, 800],
+    [50, 110, 1000],
+  ];
+
+  beforeEach(() => {
+    elm = document.createElement('div');
+  });
+  afterEach(() => {
+    elm.remove();
+  });
+  describe('when setting reference system', () => {
+    const data = [{ casingId: '1', diameter: 30, end: 202, hasShoe: true, innerDiameter: 28, start: 139.7 }];
+    const xBounds = [0, 1000] as [number, number];
+    const yBounds = [0, 1000] as [number, number];
+    const layerEvent = {
+      xBounds,
+      yBounds,
+      zFactor: 1,
+      viewportRatio: 1,
+      xRatio: 1,
+      yRatio: 1,
+      width: 1,
+      height: 1,
+      transform: zoomIdentity,
+      xScale: scaleLinear().domain(xBounds).range([0, 1]),
+      yScale: scaleLinear().domain(yBounds).range([0, 1]),
+    };
+
+    it('should render when reference system is set in constructor', () => {
+      // Arrange
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      const layer = new CasingLayer('casing-layer', { referenceSystem });
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      expect(layer.ctx.stage.addChild).toHaveBeenCalled();
+    });
+
+    it('should render when reference system is set after constructor', () => {
+      // Arrange
+      const layer = new CasingLayer('casing-layer', {});
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      layer.referenceSystem = referenceSystem;
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      expect(layer.ctx.stage.addChild).toHaveBeenCalled();
+    });
+
+    it('should not throw exception when setting data without reference system', () => {
+      // Arrange
+      const layer = new CasingLayer('casing-layer', {});
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      // Assert
+      expect(() => {
+        layer.data = data;
+      }).not.toThrow();
+    });
+  });
+});

--- a/test/casing-layer.test.ts
+++ b/test/casing-layer.test.ts
@@ -1,6 +1,5 @@
-import { scaleLinear } from 'd3-scale';
-import { zoomIdentity } from 'd3-zoom';
 import { CasingLayer, IntersectionReferenceSystem } from '../src/index';
+import { rescaleEventStub } from './test-helpers';
 
 describe('CasingLayer', () => {
   let elm: HTMLElement;
@@ -19,21 +18,6 @@ describe('CasingLayer', () => {
   });
   describe('when setting reference system', () => {
     const data = [{ casingId: '1', diameter: 30, end: 202, hasShoe: true, innerDiameter: 28, start: 139.7 }];
-    const xBounds = [0, 1000] as [number, number];
-    const yBounds = [0, 1000] as [number, number];
-    const layerEvent = {
-      xBounds,
-      yBounds,
-      zFactor: 1,
-      viewportRatio: 1,
-      xRatio: 1,
-      yRatio: 1,
-      width: 1,
-      height: 1,
-      transform: zoomIdentity,
-      xScale: scaleLinear().domain(xBounds).range([0, 1]),
-      yScale: scaleLinear().domain(yBounds).range([0, 1]),
-    };
 
     it('should render when reference system is set in constructor', () => {
       // Arrange
@@ -41,7 +25,7 @@ describe('CasingLayer', () => {
       const layer = new CasingLayer('casing-layer', { referenceSystem });
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       layer.data = data;
@@ -57,7 +41,7 @@ describe('CasingLayer', () => {
       layer.referenceSystem = referenceSystem;
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       layer.data = data;
@@ -71,7 +55,7 @@ describe('CasingLayer', () => {
       const layer = new CasingLayer('casing-layer', {});
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       // Assert

--- a/test/cement-layer.test.ts
+++ b/test/cement-layer.test.ts
@@ -1,0 +1,87 @@
+import { scaleLinear } from 'd3-scale';
+import { zoomIdentity } from 'd3-zoom';
+import { CementLayer, IntersectionReferenceSystem } from '../src/index';
+
+describe('CementLayer', () => {
+  let elm: HTMLElement;
+  const wp = [
+    [30, 40, 0],
+    [40, 70, 600],
+    [45, 100, 800],
+    [50, 110, 1000],
+  ];
+
+  beforeEach(() => {
+    elm = document.createElement('div');
+  });
+  afterEach(() => {
+    elm.remove();
+  });
+  describe('when setting reference system', () => {
+    const data = {
+      casings: [{ casingId: '1', diameter: 30, end: 200, hasShoe: true, innerDiameter: 28, start: 100 }],
+      cement: [{ casingIds: ['1'], toc: 250 }],
+      holes: [{ start: 50, end: 250, diameter: 36 }],
+    };
+    const xBounds = [0, 1000] as [number, number];
+    const yBounds = [0, 1000] as [number, number];
+    const layerEvent = {
+      xBounds,
+      yBounds,
+      zFactor: 1,
+      viewportRatio: 1,
+      xRatio: 1,
+      yRatio: 1,
+      width: 1,
+      height: 1,
+      transform: zoomIdentity,
+      xScale: scaleLinear().domain(xBounds).range([0, 1]),
+      yScale: scaleLinear().domain(yBounds).range([0, 1]),
+    };
+
+    it('should render when reference system is set in constructor', () => {
+      // Arrange
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      const layer = new CementLayer('casing-layer', { referenceSystem });
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      expect(layer.ctx.stage.addChild).toHaveBeenCalled();
+    });
+
+    it('should render when reference system is set after constructor', () => {
+      // Arrange
+      const layer = new CementLayer('casing-layer', {});
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      layer.referenceSystem = referenceSystem;
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      expect(layer.ctx.stage.addChild).toHaveBeenCalled();
+    });
+
+    it('should not throw exception when setting data without reference system', () => {
+      // Arrange
+      const layer = new CementLayer('casing-layer', {});
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      // Assert
+      expect(() => {
+        layer.data = data;
+      }).not.toThrow();
+    });
+  });
+});

--- a/test/cement-layer.test.ts
+++ b/test/cement-layer.test.ts
@@ -1,6 +1,5 @@
-import { scaleLinear } from 'd3-scale';
-import { zoomIdentity } from 'd3-zoom';
 import { CementLayer, IntersectionReferenceSystem } from '../src/index';
+import { rescaleEventStub } from './test-helpers';
 
 describe('CementLayer', () => {
   let elm: HTMLElement;
@@ -23,21 +22,6 @@ describe('CementLayer', () => {
       cement: [{ casingIds: ['1'], toc: 250 }],
       holes: [{ start: 50, end: 250, diameter: 36 }],
     };
-    const xBounds = [0, 1000] as [number, number];
-    const yBounds = [0, 1000] as [number, number];
-    const layerEvent = {
-      xBounds,
-      yBounds,
-      zFactor: 1,
-      viewportRatio: 1,
-      xRatio: 1,
-      yRatio: 1,
-      width: 1,
-      height: 1,
-      transform: zoomIdentity,
-      xScale: scaleLinear().domain(xBounds).range([0, 1]),
-      yScale: scaleLinear().domain(yBounds).range([0, 1]),
-    };
 
     it('should render when reference system is set in constructor', () => {
       // Arrange
@@ -45,7 +29,7 @@ describe('CementLayer', () => {
       const layer = new CementLayer('casing-layer', { referenceSystem });
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       layer.data = data;
@@ -61,7 +45,7 @@ describe('CementLayer', () => {
       layer.referenceSystem = referenceSystem;
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       layer.data = data;
@@ -75,7 +59,7 @@ describe('CementLayer', () => {
       const layer = new CementLayer('casing-layer', {});
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       // Assert

--- a/test/hole-layer.test.ts
+++ b/test/hole-layer.test.ts
@@ -1,6 +1,5 @@
-import { scaleLinear } from 'd3-scale';
-import { zoomIdentity } from 'd3-zoom';
 import { HoleSizeLayer, IntersectionReferenceSystem } from '../src/index';
+import { rescaleEventStub } from './test-helpers';
 
 describe('HoleSizeLayer', () => {
   let elm: HTMLElement;
@@ -19,21 +18,6 @@ describe('HoleSizeLayer', () => {
   });
   describe('when setting reference system', () => {
     const data = [{ casingId: '1', diameter: 30, end: 202, hasShoe: true, innerDiameter: 28, start: 139.7 }];
-    const xBounds = [0, 1000] as [number, number];
-    const yBounds = [0, 1000] as [number, number];
-    const layerEvent = {
-      xBounds,
-      yBounds,
-      zFactor: 1,
-      viewportRatio: 1,
-      xRatio: 1,
-      yRatio: 1,
-      width: 1,
-      height: 1,
-      transform: zoomIdentity,
-      xScale: scaleLinear().domain(xBounds).range([0, 1]),
-      yScale: scaleLinear().domain(yBounds).range([0, 1]),
-    };
 
     it('should render when reference system is set in constructor', () => {
       // Arrange
@@ -41,7 +25,7 @@ describe('HoleSizeLayer', () => {
       const layer = new HoleSizeLayer('casing-layer', { referenceSystem });
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       layer.data = data;
@@ -57,7 +41,7 @@ describe('HoleSizeLayer', () => {
       layer.referenceSystem = referenceSystem;
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       layer.data = data;
@@ -71,7 +55,7 @@ describe('HoleSizeLayer', () => {
       const layer = new HoleSizeLayer('casing-layer', {});
       layer.onMount({ elm });
       layer.onUpdate({});
-      layer.onRescale(layerEvent);
+      layer.onRescale(rescaleEventStub(data));
 
       // Act
       // Assert

--- a/test/hole-layer.test.ts
+++ b/test/hole-layer.test.ts
@@ -1,0 +1,83 @@
+import { scaleLinear } from 'd3-scale';
+import { zoomIdentity } from 'd3-zoom';
+import { HoleSizeLayer, IntersectionReferenceSystem } from '../src/index';
+
+describe('HoleSizeLayer', () => {
+  let elm: HTMLElement;
+  const wp = [
+    [30, 40, 0],
+    [40, 70, 600],
+    [45, 100, 800],
+    [50, 110, 1000],
+  ];
+
+  beforeEach(() => {
+    elm = document.createElement('div');
+  });
+  afterEach(() => {
+    elm.remove();
+  });
+  describe('when setting reference system', () => {
+    const data = [{ casingId: '1', diameter: 30, end: 202, hasShoe: true, innerDiameter: 28, start: 139.7 }];
+    const xBounds = [0, 1000] as [number, number];
+    const yBounds = [0, 1000] as [number, number];
+    const layerEvent = {
+      xBounds,
+      yBounds,
+      zFactor: 1,
+      viewportRatio: 1,
+      xRatio: 1,
+      yRatio: 1,
+      width: 1,
+      height: 1,
+      transform: zoomIdentity,
+      xScale: scaleLinear().domain(xBounds).range([0, 1]),
+      yScale: scaleLinear().domain(yBounds).range([0, 1]),
+    };
+
+    it('should render when reference system is set in constructor', () => {
+      // Arrange
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      const layer = new HoleSizeLayer('casing-layer', { referenceSystem });
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      expect(layer.ctx.stage.addChild).toHaveBeenCalled();
+    });
+
+    it('should render when reference system is set after constructor', () => {
+      // Arrange
+      const layer = new HoleSizeLayer('casing-layer', {});
+      const referenceSystem = new IntersectionReferenceSystem(wp);
+      layer.referenceSystem = referenceSystem;
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      layer.data = data;
+
+      // Assert
+      expect(layer.ctx.stage.addChild).toHaveBeenCalled();
+    });
+
+    it('should not throw exception when setting data without reference system', () => {
+      // Arrange
+      const layer = new HoleSizeLayer('casing-layer', {});
+      layer.onMount({ elm });
+      layer.onUpdate({});
+      layer.onRescale(layerEvent);
+
+      // Act
+      // Assert
+      expect(() => {
+        layer.data = data;
+      }).not.toThrow();
+    });
+  });
+});

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,0 +1,24 @@
+import { scaleLinear } from 'd3-scale';
+import { zoomIdentity } from 'd3-zoom';
+import { OnRescaleEvent } from '../src';
+
+export function rescaleEventStub(data: any): OnRescaleEvent {
+  const xBounds = [0, 1000] as [number, number];
+  const yBounds = [0, 1000] as [number, number];
+  const event = {
+    data,
+    xBounds,
+    yBounds,
+    zFactor: 1,
+    viewportRatio: 1,
+    xRatio: 1,
+    yRatio: 1,
+    width: 1,
+    height: 1,
+    transform: zoomIdentity,
+    xScale: scaleLinear().domain(xBounds).range([0, 1]),
+    yScale: scaleLinear().domain(yBounds).range([0, 1]),
+  };
+
+  return event;
+}


### PR DESCRIPTION
- add tests
- mock parts of Pixi.js for tests
- check for referenceSystem before render

I have a coming PR depending on this one that will cleanup the pixi layers some more