### PR TITLE
refactor: clean up pixilayers

### DIFF
--- a/.storybook/src/complete-example/intersection.stories.ts
+++ b/.storybook/src/complete-example/intersection.stories.ts
@@ -97,7 +97,7 @@ const renderIntersection = (scaleOptions) => {
 
     // Instantiate layers
     const gridLayer = new GridLayer('grid', { majorColor: 'black', minorColor: 'gray', majorWidth: 0.5, minorWidth: 0.5, order: 1, referenceSystem });
-    const geomodelLayer = new GeomodelLayerV2('geomodel', { order: 2, layerOpacity: 0.6 });
+    const geomodelLayer = new GeomodelLayerV2('geomodel', { order: 2, layerOpacity: 0.6, data: geolayerdata });
     const wellboreLayer = new WellborepathLayer('wellborepath', { order: 3, strokeWidth: '2px', stroke: 'red', referenceSystem });
     const holeSizeLayer = new HoleSizeLayer('holesize', { order: 4, data: holesizes, referenceSystem });
     const casingLayer = new CasingLayer('casing', { order: 5, data: casings, referenceSystem });
@@ -130,8 +130,6 @@ const renderIntersection = (scaleOptions) => {
     const controller = new Controller({ layers, ...opts });
 
     addMDOverlay(controller);
-
-    controller.getLayer('geomodel').onUpdate({ data: geolayerdata });
 
     const seismicOptions = {
       x: seismicInfo.minX,

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -1,5 +1,5 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
-import { CasingLayerOptions, OnUpdateEvent, OnRescaleEvent, Casing } from '..';
+import { CasingLayerOptions, Casing } from '..';
 import { Point, RENDERER_TYPE } from 'pixi.js';
 import { makeTubularPolygon } from '../datautils/wellboreItemShapeGenerator';
 import { createNormals, offsetPoint, offsetPoints } from '../utils/vectorUtils';
@@ -15,16 +15,9 @@ export class CasingLayer extends WellboreBaseComponentLayer {
       maxTextureDiameterScale: 2,
       ...options,
     };
-    this.render = this.render.bind(this);
   }
 
-  onUpdate(event: OnUpdateEvent): void {
-    super.onUpdate(event);
-    this.render(event);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  render(event: OnRescaleEvent | OnUpdateEvent): void {
+  render(): void {
     const { data }: { data: Casing[] } = this;
 
     if (!data || !this.rescaleEvent || !this.referenceSystem) {

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -1,6 +1,6 @@
 import { Point, Texture, RENDERER_TYPE } from 'pixi.js';
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
-import { CementLayerOptions, OnUpdateEvent, OnRescaleEvent, Cement, Casing, HoleSize, MDPoint } from '../interfaces';
+import { CementLayerOptions, Cement, Casing, HoleSize, MDPoint } from '../interfaces';
 import {
   calculateCementDiameter,
   cementDiameterChangeDepths,
@@ -29,15 +29,9 @@ export class CementLayer extends WellboreBaseComponentLayer {
       maxTextureDiameterScale: 2,
       ...options,
     };
-    this.render = this.render.bind(this);
   }
 
-  onUpdate(event: OnUpdateEvent): void {
-    super.onUpdate(event);
-    this.render(event);
-  }
-
-  render(event: OnRescaleEvent | OnUpdateEvent): void {
+  render(): void {
     if (!this.data || !this.rescaleEvent || !this.referenceSystem) {
       return;
     }

--- a/src/layers/GeomodelLayerV2.ts
+++ b/src/layers/GeomodelLayerV2.ts
@@ -1,24 +1,44 @@
 import { Graphics } from 'pixi.js';
 import { PixiLayer } from './base/PixiLayer';
-import { OnUpdateEvent } from '../interfaces';
-import { SurfaceArea, SurfaceLine } from '../datautils';
+import { OnRescaleEvent, OnUpdateEvent } from '../interfaces';
+import { SurfaceArea, SurfaceData, SurfaceLine } from '../datautils';
 import { SURFACE_LINE_WIDTH } from '../constants';
 
 export class GeomodelLayerV2 extends PixiLayer {
+  private isRendered: boolean = false;
+
+  onRescale(event: OnRescaleEvent): void {
+    super.onRescale(event);
+
+    if (!this.isRendered) {
+      this.render();
+    }
+  }
+
   onUpdate(event: OnUpdateEvent): void {
     super.onUpdate(event);
-    this.cleanUpStage();
-    if (!this.data) {
-      return;
-    }
 
-    this.data.areas.forEach((p: any) => this.generateAreaPolygon(p));
-    this.data.lines.forEach((l: any) => this.generateSurfaceLine(l));
+    this.isRendered = false;
+    this.cleanUpStage();
+    this.render();
   }
 
   cleanUpStage(): void {
     this.ctx.stage.children.forEach((g: Graphics) => g.destroy());
     this.ctx.stage.removeChildren();
+  }
+
+  render(): void {
+    const { data }: { data: SurfaceData } = this;
+
+    if (!data) {
+      return;
+    }
+
+    data.areas.forEach((a: SurfaceArea) => this.generateAreaPolygon(a));
+    data.lines.forEach((l: SurfaceLine) => this.generateSurfaceLine(l));
+
+    this.isRendered = true;
   }
 
   createPolygons = (data: any): number[][] => {

--- a/src/layers/GeomodelLayerV2.ts
+++ b/src/layers/GeomodelLayerV2.ts
@@ -1,46 +1,13 @@
-import { Graphics, Container } from 'pixi.js';
+import { Graphics } from 'pixi.js';
 import { PixiLayer } from './base/PixiLayer';
-import { GeomodelLayerOptions, OnUpdateEvent, OnRescaleEvent, OnMountEvent } from '../interfaces';
-import { SurfaceArea, SurfaceData, SurfaceLine } from '../datautils';
+import { OnUpdateEvent } from '../interfaces';
+import { SurfaceArea, SurfaceLine } from '../datautils';
 import { SURFACE_LINE_WIDTH } from '../constants';
 
 export class GeomodelLayerV2 extends PixiLayer {
-  options: GeomodelLayerOptions;
-
-  pixiContainer: Container;
-
-  polygons: any;
-
-  get data(): SurfaceData {
-    return super.getData();
-  }
-
-  set data(data: SurfaceData) {
-    this.setData(data);
-  }
-
-  getData(): SurfaceData {
-    return super.getData();
-  }
-
-  setData(data: SurfaceData): void {
-    super.setData(data);
-  }
-
-  onMount(event: OnMountEvent): void {
-    super.onMount(event);
-    this.pixiContainer = new Container();
-    this.ctx.stage.addChild(this.pixiContainer);
-  }
-
-  onUnmount(): void {
-    super.onUnmount();
-    this.pixiContainer = null;
-  }
-
   onUpdate(event: OnUpdateEvent): void {
     super.onUpdate(event);
-    this.cleanUpContainer();
+    this.cleanUpStage();
     if (!this.data) {
       return;
     }
@@ -49,9 +16,9 @@ export class GeomodelLayerV2 extends PixiLayer {
     this.data.lines.forEach((l: any) => this.generateSurfaceLine(l));
   }
 
-  cleanUpContainer(): void {
-    this.pixiContainer.children.forEach((g: Graphics) => g.destroy());
-    this.pixiContainer.removeChildren();
+  cleanUpStage(): void {
+    this.ctx.stage.children.forEach((g: Graphics) => g.destroy());
+    this.ctx.stage.removeChildren();
   }
 
   createPolygons = (data: any): number[][] => {
@@ -92,7 +59,7 @@ export class GeomodelLayerV2 extends PixiLayer {
     const polygons = this.createPolygons(s.data);
     polygons.forEach((polygon: any) => g.drawPolygon(polygon));
     g.endFill();
-    this.pixiContainer.addChild(g);
+    this.ctx.stage.addChild(g);
   };
 
   generateSurfaceLine = (s: SurfaceLine): void => {
@@ -115,6 +82,6 @@ export class GeomodelLayerV2 extends PixiLayer {
         penDown = false;
       }
     }
-    this.pixiContainer.addChild(g);
+    this.ctx.stage.addChild(g);
   };
 }

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -1,5 +1,5 @@
 import { WellboreBaseComponentLayer } from './WellboreBaseComponentLayer';
-import { HoleSizeLayerOptions, OnUpdateEvent, OnRescaleEvent, HoleSize } from '..';
+import { HoleSizeLayerOptions, HoleSize } from '..';
 import { makeTubularPolygon } from '../datautils/wellboreItemShapeGenerator';
 import { createNormals, offsetPoints } from '../utils/vectorUtils';
 import { HOLE_OUTLINE } from '../constants';
@@ -19,15 +19,9 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
       maxTextureDiameterScale: 2,
       ...options,
     };
-    this.render = this.render.bind(this);
   }
 
-  onUpdate(event: OnUpdateEvent): void {
-    super.onUpdate(event);
-    this.render(event);
-  }
-
-  render(event: OnRescaleEvent | OnUpdateEvent): void {
+  render(): void {
     const { data } = this;
 
     if (!data || !this.rescaleEvent || !this.referenceSystem) {

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -6,8 +6,6 @@ import { HOLE_OUTLINE } from '../constants';
 import { Point, RENDERER_TYPE } from 'pixi.js';
 
 export class HoleSizeLayer extends WellboreBaseComponentLayer {
-  options: HoleSizeLayerOptions;
-
   constructor(id?: string, options?: HoleSizeLayerOptions) {
     super(id, options);
     this.options = {
@@ -38,7 +36,7 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
       return;
     }
 
-    const { maxTextureDiameterScale, firstColor } = this.options;
+    const { maxTextureDiameterScale, firstColor, lineColor } = this.options as HoleSizeLayerOptions;
 
     const texture = this.createTexture(holeObject.diameter * maxTextureDiameterScale);
 
@@ -48,8 +46,6 @@ export class HoleSizeLayer extends WellboreBaseComponentLayer {
 
     const rightPath = offsetPoints(pathPoints, normals, holeObject.diameter);
     const leftPath = offsetPoints(pathPoints, normals, -holeObject.diameter);
-
-    const { lineColor } = this.options;
 
     if (pathPoints.length === 0) {
       return;

--- a/src/layers/WellboreBaseComponentLayer.ts
+++ b/src/layers/WellboreBaseComponentLayer.ts
@@ -21,7 +21,7 @@ const createGradientFill = (
   return gradient;
 };
 
-export class WellboreBaseComponentLayer extends PixiLayer {
+export abstract class WellboreBaseComponentLayer extends PixiLayer {
   _textureCache: Record<string, Texture> = {};
 
   rescaleEvent: OnRescaleEvent;
@@ -44,6 +44,7 @@ export class WellboreBaseComponentLayer extends PixiLayer {
   onUpdate(event: OnUpdateEvent): void {
     super.onUpdate(event);
     this.clear();
+    this.render();
   }
 
   onRescale(event: OnRescaleEvent): void {
@@ -64,7 +65,7 @@ export class WellboreBaseComponentLayer extends PixiLayer {
 
     if (shouldRender) {
       this.clear();
-      this.render(event);
+      this.render();
     }
   }
 
@@ -75,13 +76,7 @@ export class WellboreBaseComponentLayer extends PixiLayer {
     });
   }
 
-  // This is overridden by the extended well bore items layers (casing, hole)
-  // TODO: Look at this construct; can we do something slightly better here?
-  render(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    event: OnRescaleEvent | OnUpdateEvent,
-  ): // eslint-disable-next-line @typescript-eslint/no-empty-function
-  void {}
+  abstract render(): void;
 
   /**
    * Calculate yRatio without zFactor

--- a/src/layers/base/PixiLayer.ts
+++ b/src/layers/base/PixiLayer.ts
@@ -1,4 +1,4 @@
-import { Application, Transform, RENDERER_TYPE } from 'pixi.js';
+import { Application, RENDERER_TYPE } from 'pixi.js';
 import { Layer } from './Layer';
 import { OnMountEvent, OnRescaleEvent, OnResizeEvent, OnUnmountEvent } from '../../interfaces';
 import { DEFAULT_LAYER_HEIGHT, DEFAULT_LAYER_WIDTH } from '../../constants';
@@ -7,8 +7,6 @@ export abstract class PixiLayer extends Layer {
   elm: HTMLElement;
 
   ctx: Application;
-
-  transform: Transform;
 
   onMount(event: OnMountEvent): void {
     super.onMount(event);
@@ -61,7 +59,6 @@ export abstract class PixiLayer extends Layer {
     this.elm.remove();
     this.elm = null;
     this.ctx = null;
-    this.transform = null;
   }
 
   onResize(event: OnResizeEvent): void {


### PR DESCRIPTION
- cleanup render method on WellboreBaseComponentLayers
  Make WellboreBaseComponentLayer and it's render method abstract to allow for missing implementation
  Remove the redundant onUpdate methods on WellboreBaseComponentLayers
- render GeomodelLayerV2 on first rescale
- cleanup GeomodelLayerV2
- fix issue with redefined getters
  avoid redeclaring "options" on HoleSizeLayer just to change type signature. It is not allowed to redeclare and change a gettter to an object property