### PR TITLE
Stop clearing data before unmounting layers

### DIFF
--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -237,7 +237,6 @@ export class LayerManager {
   }
 
   destroy(): LayerManager {
-    this.clearAllData(true);
     this.removeAllLayers();
     this.layerContainer.remove();
     this.layerContainer = undefined;


### PR DESCRIPTION
Layer.clearData() calls onUpdate after clearing data. Since several sub-classes of CanvasLayer has an async render call in onUpdate it should not be called when we are doing a unmount. The result is a that the async render call tries to render to a canvas that is already destroyed.

If this introduces new memory leaks, each layer should clear it's own data in onUnmount.