### PR TITLE
fix bug in IntersectionReferenceSystem::project 

### DIFF
--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -117,7 +117,7 @@ export class IntersectionReferenceSystem {
   project(length: number): number[] {
     const { curtain } = this.interpolators;
     const { calculateDisplacementFromBottom } = this.options;
-    const cl = clamp(calculateDisplacementFromBottom ? this.length - length : length - this._offset, 0, this.length);
+    const cl = clamp(calculateDisplacementFromBottom ? this.length - (length - this._offset) : length - this._offset, 0, this.length);
     const p = curtain.getPointAtArcLength(cl, this.options);
     return p;
   }


### PR DESCRIPTION
When using IntersectionReferenceSystem with calculateDisplacementFromBottom project() method calculates distance from bottom to input MD wrong and throws of the intersection coordinates returned.