### PR TITLE
chore: upgrade to PIXI.js 6 4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "jest": "^27.4.7",
         "jest-canvas-mock": "^2.3.1",
         "mock-raf": "^1.0.1",
-        "pixi.js": "^5.3.12",
+        "pixi.js": "^6.4.2",
         "prettier": "^2.6.1",
         "rimraf": "^3.0.2",
         "rollup": "^2.39.1",
@@ -54,7 +54,7 @@
         "typescript": "^4.2.2"
       },
       "peerDependencies": {
-        "pixi.js": "^5.3.12"
+        "pixi.js": "^6.4.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4552,384 +4552,404 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.12.tgz",
-      "integrity": "sha512-JnfII2VsIeIpvyn1VMNDlhhq5BzHwwHn8sMRKhS3kFyxn4CdP0E4Ktn3/QK0vmL9sHCeTlto5Ybj3uuoKZwCWg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.4.2.tgz",
+      "integrity": "sha512-8fGPff10+vQuEfhQhOF/d/O3B3tpZvZRDUB6E8H+HAreV3S7PWk1WvC82/Q3Ru9u78M4y6zWvb0GQVT/h5JG9g==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.12.tgz",
-      "integrity": "sha512-XMpqoO+1BFIVakgHX/VlBaO4qWxg9TitvybDeXZxyVlSCG84DMNulN55jYufVp92nqHhiRr2fAIc9JDccOcNcQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.4.2.tgz",
+      "integrity": "sha512-r0cTQan9ST0N+QmaaZQso7q0Q/lk9pUXB7dez+2vrLEbP8TAnLym2V2H+ChN6TwD+EoX6qXD7oFohNbwPedNyA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2"
+      }
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.4.2.tgz",
+      "integrity": "sha512-PRA715S7WN+I9XT8tPRYMsqDnJl3D4hpC5ZccB41579kv1NBdTATdMk6G3m92RuBmonfdwGdRBYLSWVRgzgC+g==",
+      "dev": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/loaders": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.12.tgz",
-      "integrity": "sha512-UcuvZZ8cQu+ZC7ufLpKi8NfZX0FncPuxKd0Rf6u6pzO2SmHPq4C1moXYGDnkZjPFAjNYFFHC7chU+zolMtkL/g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.4.2.tgz",
+      "integrity": "sha512-qj+eviYmJqeGkMbIKSkp1FVMLglQPVyzzyo/2/0VYmSuY4m4WItC4w3wtyjDd4vBK9YxZIUBZz+LKJvKkRplLQ==",
       "dev": true
     },
     "node_modules/@pixi/core": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.12.tgz",
-      "integrity": "sha512-SKZPU2mP4UE4trWOTcubGekKwopnotbyR2X8nb68wffBd1GzMoaxyakltfJF2oCV/ivrru/biP4CkW9K6MJ56g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.4.2.tgz",
+      "integrity": "sha512-W5RWg0537uz2ni0BW9pA0gRmYGBE628e5XR4iDXO5VLSIZmc4jcaBLsPC7o1amcg1xo5Ty44yMpVpodv+GGRCw==",
       "dev": true,
       "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/runner": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/ticker": "5.3.12",
-        "@pixi/utils": "5.3.12"
+        "@types/offscreencanvas": "^2019.6.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/runner": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/ticker": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.12.tgz",
-      "integrity": "sha512-/fsH/GAxc62rvwTnmrnV8oGCkk4LwJ9pt2Jv3UIorNsjXyL0V5fGw7uZnilF2eSdu6LgQKBMWPOtBF0TNML3lg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.4.2.tgz",
+      "integrity": "sha512-mE35oRa4Ex5NOVXsuk7JldmmjBfO0gtOO7FPU3VpheOB13HLoacJ4XAa1HfAGapFiFZe+K19gOXEiOj1RyJfGA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/math": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/extract": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.12.tgz",
-      "integrity": "sha512-PRs9sKeZT+eYSD8wGUqSjHhIRrfvnLU65IIJYlmgTxYo9U4rwzykt74v09ggMj/GFUpjsILISA5VIXM1TV79PQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.4.2.tgz",
+      "integrity": "sha512-4eMqkns+NL2/DmdezjbVG4TW+eII3hvgDM3koDQNoO4yjMgU+55TTptPU9jJL/JJwntRiUECLSIHg8eZxmA5mA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.12.tgz",
-      "integrity": "sha512-/VG+ojZZwStLfiYVKcX4XsXNiPZpv40ZgiDL6igZOMqUsWn7n7dhIgytmbx6uTUWfxIPlOQH3bJGEyAHVEgzZA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.4.2.tgz",
+      "integrity": "sha512-If6a/tCPnFo0FQI/v6uy0OSqrNI8YMZMdcY7CfgklqDHx50CvhKp0d2tPYE4ETNgSpO883LARz6pi6yLAH83AA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.12.tgz",
-      "integrity": "sha512-8zuOmztmuXCl1pXQpycKTS8HmXPtkmMe6xM93Q1gT7CRLzyS97H3pQAh4YuaGOrJslOKBNDrGVzLVY95fxjcTQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.4.2.tgz",
+      "integrity": "sha512-AMvhpFFYkRw6OQuhAuwzCJZI3wjXx6gejJB9RUEOIaQBwhTeSyZqB5JpQbcpAteQZLggUPFZAm9Rf74LRjs7ZA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/settings": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/settings": "6.4.2"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.12.tgz",
-      "integrity": "sha512-CblKOry/TvFm7L7iangxYtvQgO3a9n5MsmxDUue68DWZa/iI4r/3TSnsvA+Iijr590e9GsWxy3mj9P4HBMOGTA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.4.2.tgz",
+      "integrity": "sha512-IsR2piAxGmyesqZ4OlIyv5OvUkHx3K5iL+js6vricbcbBZA9fQUjTXdZmb7RloO6Po3Amze3f9ZkuLe4CNpUDQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.12.tgz",
-      "integrity": "sha512-D/LpJxnGi85wHB6VeBpw0FQAN0mzHHUYNxCADwUhknY+SKfP5RhaYOlk79zqOuakBfQTzL3lPgMNH2EC85EJPw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.4.2.tgz",
+      "integrity": "sha512-ofY2CucTV9uhzBmKioOQMHoD+cyeycDAJ9TWLGf6/FUVSBgHLhRDFKd3IE0raXLNETGl01V9mxWEjZ8yB7/jkA==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/math": "6.4.2"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.12.tgz",
-      "integrity": "sha512-EI+foorDnYUAy7VF3fzi635u/dyf5EHZOFovGEDrHm/ZTmEJ1i6RolwexCN94vf6HGfaDrIgNmqFcKWtbIvJFA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.4.2.tgz",
+      "integrity": "sha512-euUeo/FAQ9DfnRYmxcA9wqAzU8y3VRvgptuur/sFPGgWDQqoOOLzBqRDU8/Mhj0NM9ixswrUHBTg8FN5ToP2yw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.12.tgz",
-      "integrity": "sha512-9KWmlM2zRryY6o0bfNOHAckdCk8X7g9XWZbmEIXZZs7Jr90C1+RhDreqNs8OrMukmNo2cW9hMrshHgJ9aA1ftQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.4.2.tgz",
+      "integrity": "sha512-WvtpU1JHKujwoRHP7vqcOQ700ZH6faFXVSG6+ot9giJldk1sf5xNK7tKjSEkhcQgI7VwAqwMy/z4Jho+clCPgg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.12.tgz",
-      "integrity": "sha512-uBmFvq15rX0f459/4F2EnR2UhCgfwMWVJDB1L3OnCqQePE/z3ju4mfWEwOT+I7gGejWlGNE6YLdEMVNw/3zb6w==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.4.2.tgz",
+      "integrity": "sha512-bMIuOee3ONsibRzq9/YUOPfrJ9rD5UK4ifhHRcB5sXwyRXhVK2HNkT2H4+0JQ8o7TxqjJE8neb5en9hn3ZR3SQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/sprite": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.12.tgz",
-      "integrity": "sha512-Ks7vHDfDI58r1TzKHabnQXcXzFbUu2Sb4eQ3/jnzI/xGB5Z8Q0kS7RwJtFOWNZ67HHQdoHFkQIozTUXVXHs3oA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.4.2.tgz",
+      "integrity": "sha512-CJ4BAZUM+9ykRE9NIOyTiv7oR+PoiDqn+GcI8boE9mRyJ0WZosznCYdcAwEk5k/F5+Az0z8hK3PjzTuNvrPAcw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/ticker": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/ticker": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.12.tgz",
-      "integrity": "sha512-M56m1GKpCChFqSic9xrdtQOXFqwYMvGzDXNpsKIsQbkHooaJhUR5UxSPaNiGC4qWv0TO9w8ANouxeX2v6js4eg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.4.2.tgz",
+      "integrity": "sha512-2y4JbGhhYYYdKIZfy9Evc7rcctqcXiP6xuAuIfqVgRD9SjQkxImelgCpyYT/BpjXP5jetyim8Usv07Ynx+4B0w==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/utils": "5.3.12",
-        "resource-loader": "^3.0.1"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.12.tgz",
-      "integrity": "sha512-VMccUVKSRlLFTGQu6Z450q/W6LVibaFWEo2eSZZfxz+hwjlYiqRPx4heG++4Y6tGskZK7W8l8h+2ixjmo65FCg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.4.2.tgz",
+      "integrity": "sha512-/byuwLhzln7Gahl3pT/Ckfwe4nvAQ3tAYu+38B+b18HkQWi3Ykci/QwVq/nICb5sa5tJzW3icno2qcv7zBd2xQ==",
       "dev": true
     },
     "node_modules/@pixi/mesh": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.12.tgz",
-      "integrity": "sha512-8ZiGZsZQBWoP1p8t9bSl/AfERb5l3QlwnY9zYVMDydF/UWfN1gKcYO4lKvaXw/HnLi4ZjE+OHoZVmePss9zzaw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.4.2.tgz",
+      "integrity": "sha512-zbrgcYg2EGtxj6h0SC3pSe8Nc0R5jSM0r2GJXjqdiBywsKH0c+XKdUMCi3LZ1uCbJraN5N0suOkBHTUEK1Qx3Q==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.12.tgz",
-      "integrity": "sha512-tEBEEIh96aSGJ/KObdtlNcSzVfgrl9fBhvdUDOHepSyVG+SkmX4LMqP3DkGl6iUBDiq9FBRFaRgbxEd8G2U7yw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.4.2.tgz",
+      "integrity": "sha512-fTfz+LiqhCrQ2Bnc05bURshyXOUuH1KZXKneXgUhmWb8u02Mc41mT4aylf/Ve9YhVMBL5dcsY5UTGrfn+MvIsg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/mesh": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/mesh": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.12.tgz",
-      "integrity": "sha512-hPiu8jCQJctN3OVJDgh7jqdtRgyB3qH1BWLM742MOZLjYnbOSamnqmI8snG+tba5yj/WfdjKB+8v0WNwEXlH6w==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.4.2.tgz",
+      "integrity": "sha512-TyMoSDoxd8o1J6/S/8xjJlCO4ThVOC2aJdHMP3hNX8GqjszOWZ2JONwVrPauToCPLyM76JXoDylwINB0bMh3YQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/sprite": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.12.tgz",
-      "integrity": "sha512-VQv0GMNmfyBfug9pnvN5s/ZMKJ/AXvg+4RULTpwHFtAwlCdZu9IeNb4eviSSAwtOeBAtqk5c0MQSsdOUWOeIkA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.4.2.tgz",
+      "integrity": "sha512-VP8RihmDiah3x/7jHoJe1f9PCWadWOC5m5pHE886e4KafZq6vRJAoD9SMBm2VxcVJMZAvwIXnnTd6M2paC6ijg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/display": "5.3.12"
+      "peerDependencies": {
+        "@pixi/display": "6.4.2"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.12.tgz",
-      "integrity": "sha512-qxsfCC9BsKSjBlMH1Su/AVwsrzY8NHfcut5GkVvm2wa9+ypxFwU5fVsmk6+4a9G7af3iqmOlc9YDymAvbi+e8g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.4.2.tgz",
+      "integrity": "sha512-sb+uzQ1OjXeGZaehuhmYoLtmrpt18gj4OQXa/ACebIEYZNB0fy57k1MMEhQlQvv4cOML0nglf64nzhkdNxk85A==",
       "dev": true,
-      "dependencies": {
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12"
+      "peerDependencies": {
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2"
       }
     },
-    "node_modules/@pixi/particles": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.12.tgz",
-      "integrity": "sha512-SV/gOJBFa4jpsEM90f1bz5EuMMiNAz81mu+lhiUxdQQjZ8y/S4TiK7OAiyc+hUtp97JbJ//6u+4ynGwbhV+WDA==",
+    "node_modules/@pixi/particle-container": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.4.2.tgz",
+      "integrity": "sha512-AWeeGNk0ngGBNCyY25jnYHpxLi9mZ2TKvJCFuDl7WyUDKRekJjjF5ctxtATNECIy964HFadlV31Jzrlji2sDiQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.12.tgz",
-      "integrity": "sha512-qkm8TBIb6m7FmE/Cd/yVagONDlVF5/cWFSSnk4pWA/vt/HLNrXgY9Tx0IXAk6NNK/xc5deGcLPc4iw+DlEhsQw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.4.2.tgz",
+      "integrity": "sha512-526FVALec5Hf6KVuguRLmLjnAAodpcBeZdQvMVEyMqgxZLch3f6QSwq+SITqR2lr7toqRYEWMyH7ISXdqbcRAg==",
       "dev": true,
       "dependencies": {
-        "es6-promise-polyfill": "^1.2.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "promise-polyfill": "^8.2.0"
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.12.tgz",
-      "integrity": "sha512-loZhLzV4riet9MU72WpWIYF6LgbRM78S4soeZOr5SzL1/U5mBneOOmfStaui7dN2GKQKp5GLygDF4dH3FPalnA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.4.2.tgz",
+      "integrity": "sha512-6UXNvKxCsoJVCGZslkqynkwaY+uHsSfcQHsmm/aVg6Y1bcA8Uv8JUgZVTnF195APqPLh1k3KYYch2hrdC0ip0A==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/graphics": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/text": "5.3.12",
-        "@pixi/ticker": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/graphics": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/text": "6.4.2",
+        "@pixi/ticker": "6.4.2"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.12.tgz",
-      "integrity": "sha512-I5mXx4BiP8Bx5CFIXy3XV3ABYFXbIWaY6FxWsNFkySn0KUhizN7SarPdhFGs//hJuC54EH2FsKKNa98Lfc2nCQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.4.2.tgz",
+      "integrity": "sha512-mH1//C931Rd+RB/c66t8VMNmLUGBCnefRftgijV5mBFXNgyP8Dnbig1790Qw4IDKPgiiR1mRmGDGAJAr0Xa/3A==",
       "dev": true
     },
     "node_modules/@pixi/settings": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.12.tgz",
-      "integrity": "sha512-tLAa8tpDGllgj88NMUQn2Obn9MFJfHNF/CKs8aBhfeZGU4yL4PZDtlI+tqaB1ITGl3xxyHmJK+qfmv5lJn+zyA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.4.2.tgz",
+      "integrity": "sha512-wA2PEVoHYaRiQ0/zvq8nqJZkzDT3qLRl8S7yVfL1yhsbCsh6KI0hjCwqy8b8xCAVAMwkInzWx64lvQbfActnAg==",
       "dev": true,
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.12.tgz",
-      "integrity": "sha512-vticet92RFZ3nDZ6/VDwZ7RANO0jzyXOF/5RuJf0yNVJgBoH4cNix520FfsBWE2ormD+z5t1KEmFeW4e35z2kw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.4.2.tgz",
+      "integrity": "sha512-UW3587gBSdY8iCh/t7+7j1CV9iouAQrLvRNw42gJm5iQm+GaLWpQEI3GSaQX9u47fi1C2nokeGa6uB2Hwz/48Q==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.12.tgz",
-      "integrity": "sha512-WkGdGRfqboXFzMZ/SM6pCVukYmG2E2IlpcFz7aEeWvKL2Icm4YtaCBpHHDU07vvA6fP6JrstlCx1RyTENtOeGA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.4.2.tgz",
+      "integrity": "sha512-K0/AfB+EaPmqfJr/yxsbL/sF1nEHBxeT+4+1MlTTBwNW2y9r+OyZiO/1CEmn1r3D7utFzxa+BkS1jGLVF+1klw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/ticker": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/sprite": "6.4.2",
+        "@pixi/ticker": "6.4.2"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.12.tgz",
-      "integrity": "sha512-5/gtNT46jIo7M69sixqkta1aXVhl4NTwksD9wzqjdZkQG8XPpKmHtXamROY2Fw3R+m+KGgyK8ywAf78tPvxPwg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.4.2.tgz",
+      "integrity": "sha512-2kTVlgOMDi8MmvrZJBe4pt96hIcFS89kJrZYG+aEg7DoS1oQJ1X/T68feqz0PfMHgTJtQiDqn2NbR+/S1E/HpQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/sprite": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.12.tgz",
-      "integrity": "sha512-0t5HKgLx0uWtENtkW0zVpqvmfoxqMcRAYB7Nwk2lkgZMBPCOFtFF/4Kdp9Sam5X0EBMRGkmIelW3fD6pniSvCw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.4.2.tgz",
+      "integrity": "sha512-iSKVXcH4oPNZ+XdirqMTdgo3MbbXRsoAeuXsoWum2aP4Zm94cSQ0kRGAMXg5SVhQTWF5w+tQ+JKfE/kGZqd5Vg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/loaders": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/loaders": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.12.tgz",
-      "integrity": "sha512-tvrDVetwVjq1PVDR6jq4umN/Mv/EPHioEOHhyep63yvFIBFv75mDTg2Ye0CPzkmjqwXXvAY+hHpNwuOXTB40xw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.4.2.tgz",
+      "integrity": "sha512-jX2LBjgEwKqm5lTUKh3gusSKsSPQpibdcxYMQKxMDNVqvNyGG9UqEO/FogMnGg6c5EHBKyMas26c8oXrf1oagg==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/core": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/sprite": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.12.tgz",
-      "integrity": "sha512-tiorA3XdriJKJtUhMDcKX1umE3hGbaNJ/y0ZLuQ0lCvoTLrN9674HtveutoR9KkXWguDHCSk2cY+y3mNAvjPHA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.4.2.tgz",
+      "integrity": "sha512-P+LjlEA2g2+UdHrT95wB3SoL40Z4AqMlfW6rh8WDxCtfvjafBM8Cl2sqkvd962GOrp7MuVCLYTodIs7LaYf9BQ==",
       "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/loaders": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/mesh": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/text": "5.3.12",
-        "@pixi/utils": "5.3.12"
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/loaders": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/mesh": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/text": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.12.tgz",
-      "integrity": "sha512-YNYUj94XgogipYhPOjbdFBIsy7+U6KmolvK+Av1G88GDac5SDoALb1Nt6s23fd8HIz6b4YnabHOdXGz3zPir1Q==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.4.2.tgz",
+      "integrity": "sha512-OM2U0qLiU2Z+qami7DRNkBJnx20ElQO/5mJNsoHQRH6k/po0nXlux8jcCXhh5DE9lds4RdUFAwTL4RmLT1clDw==",
       "dev": true,
-      "dependencies": {
-        "@pixi/settings": "5.3.12"
+      "peerDependencies": {
+        "@pixi/settings": "6.4.2"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.12.tgz",
-      "integrity": "sha512-PU/L852YjVbTy/6fDKQtYji6Vqcwi5FZNIjK6JXKuDPF411QfJK3QBaEqJTrexzHlc9Odr0tYECjwtXkCUR02g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.4.2.tgz",
+      "integrity": "sha512-FORUzSikNUNceS6sf2NlRcGukmJrnWCQToA6Nqk+tQ7Lvb42vDTVI66ya44O6HYM2J0nL684YeYesWbAZ+UeKg==",
       "dev": true,
       "dependencies": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "earcut": "^2.1.5",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.4.2",
+        "@pixi/settings": "6.4.2"
       }
     },
     "node_modules/@popperjs/core": {
@@ -7037,6 +7057,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/earcut": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
+      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
+      "dev": true
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.8",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
@@ -7170,6 +7196,12 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
       "integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+      "dev": true
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
       "dev": true
     },
     "node_modules/@types/overlayscrollbars": {
@@ -11861,12 +11893,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/es6-promise-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
-      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4=",
-      "dev": true
     },
     "node_modules/es6-shim": {
       "version": "0.35.6",
@@ -19378,12 +19404,6 @@
         "dom-walk": "^0.1.0"
       }
     },
-    "node_modules/mini-signals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=",
-      "dev": true
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -20394,15 +20414,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-uri": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
-      "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -20550,45 +20561,46 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.12.tgz",
-      "integrity": "sha512-XZzUhrq/m6fx3E0ESv/zXKEVR/GW82dPmbwdapIqsgAldKT2QqBYMfz1WuPf+Q9moPapywVNjjyxPvh+DNPmIg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.4.2.tgz",
+      "integrity": "sha512-8fjWgBfuSinIz0J5qXdsz10KAeDYyaa8XOcp4E1f+ug5ckE5rTPCcrSwQ8LNWA/YpdJ5irGOjv0rEA4sOcWVeQ==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "5.3.12",
-        "@pixi/app": "5.3.12",
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/extract": "5.3.12",
-        "@pixi/filter-alpha": "5.3.12",
-        "@pixi/filter-blur": "5.3.12",
-        "@pixi/filter-color-matrix": "5.3.12",
-        "@pixi/filter-displacement": "5.3.12",
-        "@pixi/filter-fxaa": "5.3.12",
-        "@pixi/filter-noise": "5.3.12",
-        "@pixi/graphics": "5.3.12",
-        "@pixi/interaction": "5.3.12",
-        "@pixi/loaders": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/mesh": "5.3.12",
-        "@pixi/mesh-extras": "5.3.12",
-        "@pixi/mixin-cache-as-bitmap": "5.3.12",
-        "@pixi/mixin-get-child-by-name": "5.3.12",
-        "@pixi/mixin-get-global-position": "5.3.12",
-        "@pixi/particles": "5.3.12",
-        "@pixi/polyfill": "5.3.12",
-        "@pixi/prepare": "5.3.12",
-        "@pixi/runner": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/sprite-animated": "5.3.12",
-        "@pixi/sprite-tiling": "5.3.12",
-        "@pixi/spritesheet": "5.3.12",
-        "@pixi/text": "5.3.12",
-        "@pixi/text-bitmap": "5.3.12",
-        "@pixi/ticker": "5.3.12",
-        "@pixi/utils": "5.3.12"
+        "@pixi/accessibility": "6.4.2",
+        "@pixi/app": "6.4.2",
+        "@pixi/compressed-textures": "6.4.2",
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/extract": "6.4.2",
+        "@pixi/filter-alpha": "6.4.2",
+        "@pixi/filter-blur": "6.4.2",
+        "@pixi/filter-color-matrix": "6.4.2",
+        "@pixi/filter-displacement": "6.4.2",
+        "@pixi/filter-fxaa": "6.4.2",
+        "@pixi/filter-noise": "6.4.2",
+        "@pixi/graphics": "6.4.2",
+        "@pixi/interaction": "6.4.2",
+        "@pixi/loaders": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/mesh": "6.4.2",
+        "@pixi/mesh-extras": "6.4.2",
+        "@pixi/mixin-cache-as-bitmap": "6.4.2",
+        "@pixi/mixin-get-child-by-name": "6.4.2",
+        "@pixi/mixin-get-global-position": "6.4.2",
+        "@pixi/particle-container": "6.4.2",
+        "@pixi/polyfill": "6.4.2",
+        "@pixi/prepare": "6.4.2",
+        "@pixi/runner": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/sprite": "6.4.2",
+        "@pixi/sprite-animated": "6.4.2",
+        "@pixi/sprite-tiling": "6.4.2",
+        "@pixi/spritesheet": "6.4.2",
+        "@pixi/text": "6.4.2",
+        "@pixi/text-bitmap": "6.4.2",
+        "@pixi/ticker": "6.4.2",
+        "@pixi/utils": "6.4.2"
       },
       "funding": {
         "type": "opencollective",
@@ -20941,6 +20953,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
       "dev": true
     },
     "node_modules/promise.allsettled": {
@@ -22026,16 +22044,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/resource-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
-      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
-      "dev": true,
-      "dependencies": {
-        "mini-signals": "^1.2.0",
-        "parse-uri": "^1.0.0"
       }
     },
     "node_modules/ret": {
@@ -29153,378 +29161,255 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.12.tgz",
-      "integrity": "sha512-JnfII2VsIeIpvyn1VMNDlhhq5BzHwwHn8sMRKhS3kFyxn4CdP0E4Ktn3/QK0vmL9sHCeTlto5Ybj3uuoKZwCWg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.4.2.tgz",
+      "integrity": "sha512-8fGPff10+vQuEfhQhOF/d/O3B3tpZvZRDUB6E8H+HAreV3S7PWk1WvC82/Q3Ru9u78M4y6zWvb0GQVT/h5JG9g==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/app": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.12.tgz",
-      "integrity": "sha512-XMpqoO+1BFIVakgHX/VlBaO4qWxg9TitvybDeXZxyVlSCG84DMNulN55jYufVp92nqHhiRr2fAIc9JDccOcNcQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.4.2.tgz",
+      "integrity": "sha512-r0cTQan9ST0N+QmaaZQso7q0Q/lk9pUXB7dez+2vrLEbP8TAnLym2V2H+ChN6TwD+EoX6qXD7oFohNbwPedNyA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12"
-      }
+      "requires": {}
+    },
+    "@pixi/compressed-textures": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.4.2.tgz",
+      "integrity": "sha512-PRA715S7WN+I9XT8tPRYMsqDnJl3D4hpC5ZccB41579kv1NBdTATdMk6G3m92RuBmonfdwGdRBYLSWVRgzgC+g==",
+      "dev": true,
+      "requires": {}
     },
     "@pixi/constants": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.12.tgz",
-      "integrity": "sha512-UcuvZZ8cQu+ZC7ufLpKi8NfZX0FncPuxKd0Rf6u6pzO2SmHPq4C1moXYGDnkZjPFAjNYFFHC7chU+zolMtkL/g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.4.2.tgz",
+      "integrity": "sha512-qj+eviYmJqeGkMbIKSkp1FVMLglQPVyzzyo/2/0VYmSuY4m4WItC4w3wtyjDd4vBK9YxZIUBZz+LKJvKkRplLQ==",
       "dev": true
     },
     "@pixi/core": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.12.tgz",
-      "integrity": "sha512-SKZPU2mP4UE4trWOTcubGekKwopnotbyR2X8nb68wffBd1GzMoaxyakltfJF2oCV/ivrru/biP4CkW9K6MJ56g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.4.2.tgz",
+      "integrity": "sha512-W5RWg0537uz2ni0BW9pA0gRmYGBE628e5XR4iDXO5VLSIZmc4jcaBLsPC7o1amcg1xo5Ty44yMpVpodv+GGRCw==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/runner": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/ticker": "5.3.12",
-        "@pixi/utils": "5.3.12"
+        "@types/offscreencanvas": "^2019.6.4"
       }
     },
     "@pixi/display": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.12.tgz",
-      "integrity": "sha512-/fsH/GAxc62rvwTnmrnV8oGCkk4LwJ9pt2Jv3UIorNsjXyL0V5fGw7uZnilF2eSdu6LgQKBMWPOtBF0TNML3lg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.4.2.tgz",
+      "integrity": "sha512-mE35oRa4Ex5NOVXsuk7JldmmjBfO0gtOO7FPU3VpheOB13HLoacJ4XAa1HfAGapFiFZe+K19gOXEiOj1RyJfGA==",
       "dev": true,
-      "requires": {
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/extract": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.12.tgz",
-      "integrity": "sha512-PRs9sKeZT+eYSD8wGUqSjHhIRrfvnLU65IIJYlmgTxYo9U4rwzykt74v09ggMj/GFUpjsILISA5VIXM1TV79PQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.4.2.tgz",
+      "integrity": "sha512-4eMqkns+NL2/DmdezjbVG4TW+eII3hvgDM3koDQNoO4yjMgU+55TTptPU9jJL/JJwntRiUECLSIHg8eZxmA5mA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/filter-alpha": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.12.tgz",
-      "integrity": "sha512-/VG+ojZZwStLfiYVKcX4XsXNiPZpv40ZgiDL6igZOMqUsWn7n7dhIgytmbx6uTUWfxIPlOQH3bJGEyAHVEgzZA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.4.2.tgz",
+      "integrity": "sha512-If6a/tCPnFo0FQI/v6uy0OSqrNI8YMZMdcY7CfgklqDHx50CvhKp0d2tPYE4ETNgSpO883LARz6pi6yLAH83AA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/filter-blur": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.12.tgz",
-      "integrity": "sha512-8zuOmztmuXCl1pXQpycKTS8HmXPtkmMe6xM93Q1gT7CRLzyS97H3pQAh4YuaGOrJslOKBNDrGVzLVY95fxjcTQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.4.2.tgz",
+      "integrity": "sha512-AMvhpFFYkRw6OQuhAuwzCJZI3wjXx6gejJB9RUEOIaQBwhTeSyZqB5JpQbcpAteQZLggUPFZAm9Rf74LRjs7ZA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/settings": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/filter-color-matrix": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.12.tgz",
-      "integrity": "sha512-CblKOry/TvFm7L7iangxYtvQgO3a9n5MsmxDUue68DWZa/iI4r/3TSnsvA+Iijr590e9GsWxy3mj9P4HBMOGTA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.4.2.tgz",
+      "integrity": "sha512-IsR2piAxGmyesqZ4OlIyv5OvUkHx3K5iL+js6vricbcbBZA9fQUjTXdZmb7RloO6Po3Amze3f9ZkuLe4CNpUDQ==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/filter-displacement": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.12.tgz",
-      "integrity": "sha512-D/LpJxnGi85wHB6VeBpw0FQAN0mzHHUYNxCADwUhknY+SKfP5RhaYOlk79zqOuakBfQTzL3lPgMNH2EC85EJPw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.4.2.tgz",
+      "integrity": "sha512-ofY2CucTV9uhzBmKioOQMHoD+cyeycDAJ9TWLGf6/FUVSBgHLhRDFKd3IE0raXLNETGl01V9mxWEjZ8yB7/jkA==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/filter-fxaa": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.12.tgz",
-      "integrity": "sha512-EI+foorDnYUAy7VF3fzi635u/dyf5EHZOFovGEDrHm/ZTmEJ1i6RolwexCN94vf6HGfaDrIgNmqFcKWtbIvJFA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.4.2.tgz",
+      "integrity": "sha512-euUeo/FAQ9DfnRYmxcA9wqAzU8y3VRvgptuur/sFPGgWDQqoOOLzBqRDU8/Mhj0NM9ixswrUHBTg8FN5ToP2yw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/filter-noise": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.12.tgz",
-      "integrity": "sha512-9KWmlM2zRryY6o0bfNOHAckdCk8X7g9XWZbmEIXZZs7Jr90C1+RhDreqNs8OrMukmNo2cW9hMrshHgJ9aA1ftQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.4.2.tgz",
+      "integrity": "sha512-WvtpU1JHKujwoRHP7vqcOQ700ZH6faFXVSG6+ot9giJldk1sf5xNK7tKjSEkhcQgI7VwAqwMy/z4Jho+clCPgg==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/graphics": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.12.tgz",
-      "integrity": "sha512-uBmFvq15rX0f459/4F2EnR2UhCgfwMWVJDB1L3OnCqQePE/z3ju4mfWEwOT+I7gGejWlGNE6YLdEMVNw/3zb6w==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.4.2.tgz",
+      "integrity": "sha512-bMIuOee3ONsibRzq9/YUOPfrJ9rD5UK4ifhHRcB5sXwyRXhVK2HNkT2H4+0JQ8o7TxqjJE8neb5en9hn3ZR3SQ==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/interaction": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.12.tgz",
-      "integrity": "sha512-Ks7vHDfDI58r1TzKHabnQXcXzFbUu2Sb4eQ3/jnzI/xGB5Z8Q0kS7RwJtFOWNZ67HHQdoHFkQIozTUXVXHs3oA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.4.2.tgz",
+      "integrity": "sha512-CJ4BAZUM+9ykRE9NIOyTiv7oR+PoiDqn+GcI8boE9mRyJ0WZosznCYdcAwEk5k/F5+Az0z8hK3PjzTuNvrPAcw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/ticker": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/loaders": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.12.tgz",
-      "integrity": "sha512-M56m1GKpCChFqSic9xrdtQOXFqwYMvGzDXNpsKIsQbkHooaJhUR5UxSPaNiGC4qWv0TO9w8ANouxeX2v6js4eg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.4.2.tgz",
+      "integrity": "sha512-2y4JbGhhYYYdKIZfy9Evc7rcctqcXiP6xuAuIfqVgRD9SjQkxImelgCpyYT/BpjXP5jetyim8Usv07Ynx+4B0w==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/utils": "5.3.12",
-        "resource-loader": "^3.0.1"
-      }
+      "requires": {}
     },
     "@pixi/math": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.12.tgz",
-      "integrity": "sha512-VMccUVKSRlLFTGQu6Z450q/W6LVibaFWEo2eSZZfxz+hwjlYiqRPx4heG++4Y6tGskZK7W8l8h+2ixjmo65FCg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.4.2.tgz",
+      "integrity": "sha512-/byuwLhzln7Gahl3pT/Ckfwe4nvAQ3tAYu+38B+b18HkQWi3Ykci/QwVq/nICb5sa5tJzW3icno2qcv7zBd2xQ==",
       "dev": true
     },
     "@pixi/mesh": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.12.tgz",
-      "integrity": "sha512-8ZiGZsZQBWoP1p8t9bSl/AfERb5l3QlwnY9zYVMDydF/UWfN1gKcYO4lKvaXw/HnLi4ZjE+OHoZVmePss9zzaw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.4.2.tgz",
+      "integrity": "sha512-zbrgcYg2EGtxj6h0SC3pSe8Nc0R5jSM0r2GJXjqdiBywsKH0c+XKdUMCi3LZ1uCbJraN5N0suOkBHTUEK1Qx3Q==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/mesh-extras": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.12.tgz",
-      "integrity": "sha512-tEBEEIh96aSGJ/KObdtlNcSzVfgrl9fBhvdUDOHepSyVG+SkmX4LMqP3DkGl6iUBDiq9FBRFaRgbxEd8G2U7yw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.4.2.tgz",
+      "integrity": "sha512-fTfz+LiqhCrQ2Bnc05bURshyXOUuH1KZXKneXgUhmWb8u02Mc41mT4aylf/Ve9YhVMBL5dcsY5UTGrfn+MvIsg==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/mesh": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.12.tgz",
-      "integrity": "sha512-hPiu8jCQJctN3OVJDgh7jqdtRgyB3qH1BWLM742MOZLjYnbOSamnqmI8snG+tba5yj/WfdjKB+8v0WNwEXlH6w==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.4.2.tgz",
+      "integrity": "sha512-TyMoSDoxd8o1J6/S/8xjJlCO4ThVOC2aJdHMP3hNX8GqjszOWZ2JONwVrPauToCPLyM76JXoDylwINB0bMh3YQ==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.12.tgz",
-      "integrity": "sha512-VQv0GMNmfyBfug9pnvN5s/ZMKJ/AXvg+4RULTpwHFtAwlCdZu9IeNb4eviSSAwtOeBAtqk5c0MQSsdOUWOeIkA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.4.2.tgz",
+      "integrity": "sha512-VP8RihmDiah3x/7jHoJe1f9PCWadWOC5m5pHE886e4KafZq6vRJAoD9SMBm2VxcVJMZAvwIXnnTd6M2paC6ijg==",
       "dev": true,
-      "requires": {
-        "@pixi/display": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.12.tgz",
-      "integrity": "sha512-qxsfCC9BsKSjBlMH1Su/AVwsrzY8NHfcut5GkVvm2wa9+ypxFwU5fVsmk6+4a9G7af3iqmOlc9YDymAvbi+e8g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.4.2.tgz",
+      "integrity": "sha512-sb+uzQ1OjXeGZaehuhmYoLtmrpt18gj4OQXa/ACebIEYZNB0fy57k1MMEhQlQvv4cOML0nglf64nzhkdNxk85A==",
       "dev": true,
-      "requires": {
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12"
-      }
+      "requires": {}
     },
-    "@pixi/particles": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.12.tgz",
-      "integrity": "sha512-SV/gOJBFa4jpsEM90f1bz5EuMMiNAz81mu+lhiUxdQQjZ8y/S4TiK7OAiyc+hUtp97JbJ//6u+4ynGwbhV+WDA==",
+    "@pixi/particle-container": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.4.2.tgz",
+      "integrity": "sha512-AWeeGNk0ngGBNCyY25jnYHpxLi9mZ2TKvJCFuDl7WyUDKRekJjjF5ctxtATNECIy964HFadlV31Jzrlji2sDiQ==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/polyfill": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.12.tgz",
-      "integrity": "sha512-qkm8TBIb6m7FmE/Cd/yVagONDlVF5/cWFSSnk4pWA/vt/HLNrXgY9Tx0IXAk6NNK/xc5deGcLPc4iw+DlEhsQw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.4.2.tgz",
+      "integrity": "sha512-526FVALec5Hf6KVuguRLmLjnAAodpcBeZdQvMVEyMqgxZLch3f6QSwq+SITqR2lr7toqRYEWMyH7ISXdqbcRAg==",
       "dev": true,
       "requires": {
-        "es6-promise-polyfill": "^1.2.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "promise-polyfill": "^8.2.0"
       }
     },
     "@pixi/prepare": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.12.tgz",
-      "integrity": "sha512-loZhLzV4riet9MU72WpWIYF6LgbRM78S4soeZOr5SzL1/U5mBneOOmfStaui7dN2GKQKp5GLygDF4dH3FPalnA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.4.2.tgz",
+      "integrity": "sha512-6UXNvKxCsoJVCGZslkqynkwaY+uHsSfcQHsmm/aVg6Y1bcA8Uv8JUgZVTnF195APqPLh1k3KYYch2hrdC0ip0A==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/graphics": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/text": "5.3.12",
-        "@pixi/ticker": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/runner": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.12.tgz",
-      "integrity": "sha512-I5mXx4BiP8Bx5CFIXy3XV3ABYFXbIWaY6FxWsNFkySn0KUhizN7SarPdhFGs//hJuC54EH2FsKKNa98Lfc2nCQ==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.4.2.tgz",
+      "integrity": "sha512-mH1//C931Rd+RB/c66t8VMNmLUGBCnefRftgijV5mBFXNgyP8Dnbig1790Qw4IDKPgiiR1mRmGDGAJAr0Xa/3A==",
       "dev": true
     },
     "@pixi/settings": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.12.tgz",
-      "integrity": "sha512-tLAa8tpDGllgj88NMUQn2Obn9MFJfHNF/CKs8aBhfeZGU4yL4PZDtlI+tqaB1ITGl3xxyHmJK+qfmv5lJn+zyA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.4.2.tgz",
+      "integrity": "sha512-wA2PEVoHYaRiQ0/zvq8nqJZkzDT3qLRl8S7yVfL1yhsbCsh6KI0hjCwqy8b8xCAVAMwkInzWx64lvQbfActnAg==",
       "dev": true,
       "requires": {
         "ismobilejs": "^1.1.0"
       }
     },
     "@pixi/sprite": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.12.tgz",
-      "integrity": "sha512-vticet92RFZ3nDZ6/VDwZ7RANO0jzyXOF/5RuJf0yNVJgBoH4cNix520FfsBWE2ormD+z5t1KEmFeW4e35z2kw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.4.2.tgz",
+      "integrity": "sha512-UW3587gBSdY8iCh/t7+7j1CV9iouAQrLvRNw42gJm5iQm+GaLWpQEI3GSaQX9u47fi1C2nokeGa6uB2Hwz/48Q==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/sprite-animated": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.12.tgz",
-      "integrity": "sha512-WkGdGRfqboXFzMZ/SM6pCVukYmG2E2IlpcFz7aEeWvKL2Icm4YtaCBpHHDU07vvA6fP6JrstlCx1RyTENtOeGA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.4.2.tgz",
+      "integrity": "sha512-K0/AfB+EaPmqfJr/yxsbL/sF1nEHBxeT+4+1MlTTBwNW2y9r+OyZiO/1CEmn1r3D7utFzxa+BkS1jGLVF+1klw==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/ticker": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/sprite-tiling": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.12.tgz",
-      "integrity": "sha512-5/gtNT46jIo7M69sixqkta1aXVhl4NTwksD9wzqjdZkQG8XPpKmHtXamROY2Fw3R+m+KGgyK8ywAf78tPvxPwg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.4.2.tgz",
+      "integrity": "sha512-2kTVlgOMDi8MmvrZJBe4pt96hIcFS89kJrZYG+aEg7DoS1oQJ1X/T68feqz0PfMHgTJtQiDqn2NbR+/S1E/HpQ==",
       "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/spritesheet": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.12.tgz",
-      "integrity": "sha512-0t5HKgLx0uWtENtkW0zVpqvmfoxqMcRAYB7Nwk2lkgZMBPCOFtFF/4Kdp9Sam5X0EBMRGkmIelW3fD6pniSvCw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.4.2.tgz",
+      "integrity": "sha512-iSKVXcH4oPNZ+XdirqMTdgo3MbbXRsoAeuXsoWum2aP4Zm94cSQ0kRGAMXg5SVhQTWF5w+tQ+JKfE/kGZqd5Vg==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/loaders": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/text": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.12.tgz",
-      "integrity": "sha512-tvrDVetwVjq1PVDR6jq4umN/Mv/EPHioEOHhyep63yvFIBFv75mDTg2Ye0CPzkmjqwXXvAY+hHpNwuOXTB40xw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.4.2.tgz",
+      "integrity": "sha512-jX2LBjgEwKqm5lTUKh3gusSKsSPQpibdcxYMQKxMDNVqvNyGG9UqEO/FogMnGg6c5EHBKyMas26c8oXrf1oagg==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/text-bitmap": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.12.tgz",
-      "integrity": "sha512-tiorA3XdriJKJtUhMDcKX1umE3hGbaNJ/y0ZLuQ0lCvoTLrN9674HtveutoR9KkXWguDHCSk2cY+y3mNAvjPHA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.4.2.tgz",
+      "integrity": "sha512-P+LjlEA2g2+UdHrT95wB3SoL40Z4AqMlfW6rh8WDxCtfvjafBM8Cl2sqkvd962GOrp7MuVCLYTodIs7LaYf9BQ==",
       "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/loaders": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/mesh": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/text": "5.3.12",
-        "@pixi/utils": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/ticker": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.12.tgz",
-      "integrity": "sha512-YNYUj94XgogipYhPOjbdFBIsy7+U6KmolvK+Av1G88GDac5SDoALb1Nt6s23fd8HIz6b4YnabHOdXGz3zPir1Q==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.4.2.tgz",
+      "integrity": "sha512-OM2U0qLiU2Z+qami7DRNkBJnx20ElQO/5mJNsoHQRH6k/po0nXlux8jcCXhh5DE9lds4RdUFAwTL4RmLT1clDw==",
       "dev": true,
-      "requires": {
-        "@pixi/settings": "5.3.12"
-      }
+      "requires": {}
     },
     "@pixi/utils": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.12.tgz",
-      "integrity": "sha512-PU/L852YjVbTy/6fDKQtYji6Vqcwi5FZNIjK6JXKuDPF411QfJK3QBaEqJTrexzHlc9Odr0tYECjwtXkCUR02g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.4.2.tgz",
+      "integrity": "sha512-FORUzSikNUNceS6sf2NlRcGukmJrnWCQToA6Nqk+tQ7Lvb42vDTVI66ya44O6HYM2J0nL684YeYesWbAZ+UeKg==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "earcut": "^2.1.5",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -31090,6 +30975,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "@types/earcut": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
+      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
+      "dev": true
+    },
     "@types/geojson": {
       "version": "7946.0.8",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
@@ -31223,6 +31114,12 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
       "integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+      "dev": true
+    },
+    "@types/offscreencanvas": {
+      "version": "2019.7.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
       "dev": true
     },
     "@types/overlayscrollbars": {
@@ -34953,12 +34850,6 @@
       "version": "4.6.5",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.5.tgz",
       "integrity": "sha512-vfQ4UAai8szn0sAubCy97xnZ4sJVDD1gt/Grn736hg8D7540wemIb1YPrYZSTqlM2H69EQX1or4HU/tSwRTI3w==",
-      "dev": true
-    },
-    "es6-promise-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
-      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4=",
       "dev": true
     },
     "es6-shim": {
@@ -40739,12 +40630,6 @@
         "dom-walk": "^0.1.0"
       }
     },
-    "mini-signals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=",
-      "dev": true
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -41569,12 +41454,6 @@
         "lines-and-columns": "^1.1.6"
       }
     },
-    "parse-uri": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
-      "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
-      "dev": true
-    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -41689,45 +41568,46 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.12.tgz",
-      "integrity": "sha512-XZzUhrq/m6fx3E0ESv/zXKEVR/GW82dPmbwdapIqsgAldKT2QqBYMfz1WuPf+Q9moPapywVNjjyxPvh+DNPmIg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.4.2.tgz",
+      "integrity": "sha512-8fjWgBfuSinIz0J5qXdsz10KAeDYyaa8XOcp4E1f+ug5ckE5rTPCcrSwQ8LNWA/YpdJ5irGOjv0rEA4sOcWVeQ==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "5.3.12",
-        "@pixi/app": "5.3.12",
-        "@pixi/constants": "5.3.12",
-        "@pixi/core": "5.3.12",
-        "@pixi/display": "5.3.12",
-        "@pixi/extract": "5.3.12",
-        "@pixi/filter-alpha": "5.3.12",
-        "@pixi/filter-blur": "5.3.12",
-        "@pixi/filter-color-matrix": "5.3.12",
-        "@pixi/filter-displacement": "5.3.12",
-        "@pixi/filter-fxaa": "5.3.12",
-        "@pixi/filter-noise": "5.3.12",
-        "@pixi/graphics": "5.3.12",
-        "@pixi/interaction": "5.3.12",
-        "@pixi/loaders": "5.3.12",
-        "@pixi/math": "5.3.12",
-        "@pixi/mesh": "5.3.12",
-        "@pixi/mesh-extras": "5.3.12",
-        "@pixi/mixin-cache-as-bitmap": "5.3.12",
-        "@pixi/mixin-get-child-by-name": "5.3.12",
-        "@pixi/mixin-get-global-position": "5.3.12",
-        "@pixi/particles": "5.3.12",
-        "@pixi/polyfill": "5.3.12",
-        "@pixi/prepare": "5.3.12",
-        "@pixi/runner": "5.3.12",
-        "@pixi/settings": "5.3.12",
-        "@pixi/sprite": "5.3.12",
-        "@pixi/sprite-animated": "5.3.12",
-        "@pixi/sprite-tiling": "5.3.12",
-        "@pixi/spritesheet": "5.3.12",
-        "@pixi/text": "5.3.12",
-        "@pixi/text-bitmap": "5.3.12",
-        "@pixi/ticker": "5.3.12",
-        "@pixi/utils": "5.3.12"
+        "@pixi/accessibility": "6.4.2",
+        "@pixi/app": "6.4.2",
+        "@pixi/compressed-textures": "6.4.2",
+        "@pixi/constants": "6.4.2",
+        "@pixi/core": "6.4.2",
+        "@pixi/display": "6.4.2",
+        "@pixi/extract": "6.4.2",
+        "@pixi/filter-alpha": "6.4.2",
+        "@pixi/filter-blur": "6.4.2",
+        "@pixi/filter-color-matrix": "6.4.2",
+        "@pixi/filter-displacement": "6.4.2",
+        "@pixi/filter-fxaa": "6.4.2",
+        "@pixi/filter-noise": "6.4.2",
+        "@pixi/graphics": "6.4.2",
+        "@pixi/interaction": "6.4.2",
+        "@pixi/loaders": "6.4.2",
+        "@pixi/math": "6.4.2",
+        "@pixi/mesh": "6.4.2",
+        "@pixi/mesh-extras": "6.4.2",
+        "@pixi/mixin-cache-as-bitmap": "6.4.2",
+        "@pixi/mixin-get-child-by-name": "6.4.2",
+        "@pixi/mixin-get-global-position": "6.4.2",
+        "@pixi/particle-container": "6.4.2",
+        "@pixi/polyfill": "6.4.2",
+        "@pixi/prepare": "6.4.2",
+        "@pixi/runner": "6.4.2",
+        "@pixi/settings": "6.4.2",
+        "@pixi/sprite": "6.4.2",
+        "@pixi/sprite-animated": "6.4.2",
+        "@pixi/sprite-tiling": "6.4.2",
+        "@pixi/spritesheet": "6.4.2",
+        "@pixi/text": "6.4.2",
+        "@pixi/text-bitmap": "6.4.2",
+        "@pixi/ticker": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "pkg-dir": {
@@ -41985,6 +41865,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
+      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
       "dev": true
     },
     "promise.allsettled": {
@@ -42834,16 +42720,6 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
-    },
-    "resource-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
-      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
-      "dev": true,
-      "requires": {
-        "mini-signals": "^1.2.0",
-        "parse-uri": "^1.0.0"
-      }
     },
     "ret": {
       "version": "0.1.15",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jest": "^27.4.7",
     "jest-canvas-mock": "^2.3.1",
     "mock-raf": "^1.0.1",
-    "pixi.js": "^5.3.12",
+    "pixi.js": "^6.4.2",
     "prettier": "^2.6.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.39.1",
@@ -89,7 +89,7 @@
     ]
   },
   "peerDependencies": {
-    "pixi.js": "^5.3.12"
+    "pixi.js": "^6.4.2"
   },
   "dependencies": {
     "@equinor/videx-math": "^1.0.12",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,5 @@
 import { ZoomTransform } from 'd3-zoom';
-import { Application, Graphics } from 'pixi.js';
+import { Graphics, IApplicationOptions } from 'pixi.js';
 import { Layer } from './layers/base/Layer';
 import { IntersectionReferenceSystem } from './control/IntersectionReferenceSystem';
 import Vector2 from '@equinor/videx-vector2';
@@ -92,7 +92,7 @@ export interface CementLayerOptions extends WellComponentBaseOptions {
 }
 
 export interface PixiLayerOptions extends LayerOptions {
-  pixiApplicationOptions?: PixiApplicationOptions;
+  pixiApplicationOptions?: IApplicationOptions;
 }
 
 export interface WellComponentBaseOptions extends PixiLayerOptions {
@@ -206,6 +206,3 @@ export interface CalloutOptions extends LayerOptions {
   offsetMax?: number;
   offsetFactor?: number;
 }
-
-type PixiApplicationConstructorParameters = ConstructorParameters<typeof Application>;
-type PixiApplicationOptions = PixiApplicationConstructorParameters[0];

--- a/src/layers/base/PixiLayer.ts
+++ b/src/layers/base/PixiLayer.ts
@@ -1,4 +1,4 @@
-import { Application, RENDERER_TYPE } from 'pixi.js';
+import { Application, Renderer, RENDERER_TYPE } from 'pixi.js';
 import { Layer } from './Layer';
 import { OnMountEvent, OnRescaleEvent, OnResizeEvent, OnUnmountEvent, PixiLayerOptions } from '../../interfaces';
 import { DEFAULT_LAYER_HEIGHT, DEFAULT_LAYER_WIDTH } from '../../constants';
@@ -47,7 +47,11 @@ export abstract class PixiLayer extends Layer {
 
     // Get renderType and clContext before we destroy the renderer
     const renderType = this.renderType();
-    const glContext = this.ctx.renderer?.gl;
+
+    let glContext;
+    if (this.ctx.renderer instanceof Renderer) {
+      glContext = this.ctx.renderer?.gl;
+    }
 
     this.ctx.stop();
     this.ctx.destroy(true, { children: true, texture: true, baseTexture: true });
@@ -58,7 +62,7 @@ export abstract class PixiLayer extends Layer {
      *
      * Cleaning up our self since it still seems to work and fix issue with lingering contexts
      */
-    if (renderType === RENDERER_TYPE.WEBGL) {
+    if (renderType === RENDERER_TYPE.WEBGL && glContext) {
       glContext?.getExtension('WEBGL_lose_context')?.loseContext();
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": ["es5", "DOM", "ES2019.array"],
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
- upgrade pixi.js to 6.4.2
- tsconfig change, set skipLibCheck to true. Stop type checking of dependencies. No need for this library to typecheck dependencies.
- Update to changes in PIXI.js types
