### PR TITLE
feat: update pixi visibility toggle

### DIFF
--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -114,7 +114,7 @@ export class LayerManager<T> {
   }
 
   getLayer(layerId: string): Layer<T> {
-    return this.layers.find((l) => l.id === layerId);
+    return this.layers.find((l) => l.id === layerId || l.getInternalLayerIds().includes(layerId));
   }
 
   initLayer(layer: Layer<T>, params?: LayerOptions<T>): LayerManager<T> {
@@ -136,13 +136,21 @@ export class LayerManager<T> {
 
   showLayer(layerId: string): LayerManager<T> {
     const layer = this.getLayer(layerId);
-    layer.setVisibility(true);
+    if (!layer) {
+      return;
+    }
+    layer.setVisibility(true, layerId);
     layer.onRescale(this.zoomPanHandler.currentStateAsEvent());
     return this;
   }
 
   hideLayer(layerId: string): LayerManager<T> {
-    this.getLayer(layerId).setVisibility(false);
+    const layer = this.getLayer(layerId);
+    if (!layer) {
+      return;
+    }
+    layer.setVisibility(false, layerId);
+    layer.onRescale(this.zoomPanHandler.currentStateAsEvent());
     return this;
   }
 

--- a/src/layers/CalloutCanvasLayer.ts
+++ b/src/layers/CalloutCanvasLayer.ts
@@ -335,4 +335,8 @@ export class CalloutCanvasLayer<T extends Annotation[]> extends CanvasLayer<T> {
       }
     }
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/CasingAndCementLayer.ts
+++ b/src/layers/CasingAndCementLayer.ts
@@ -219,7 +219,7 @@ export class CasingAndCementLayer<T extends CasingAndCementData> extends Wellbor
 
     attachedCasings.sort((a: Casing, b: Casing) => a.end - b.end); // ascending
     const bottomOfCement = attachedCasings[attachedCasings.length - 1].end;
-    // console.log({ attachedCasings });
+
     const { outerCasings, holes: overlappingHoles } = findIntersectingItems(cement, bottomOfCement, attachedCasings, casings, holes);
 
     const innerDiameterIntervals = attachedCasings;
@@ -313,8 +313,8 @@ export class CasingAndCementLayer<T extends CasingAndCementData> extends Wellbor
   }
 
   getInternalLayerIds(): string[] {
-    const internalLayers = (this.options as CasingAndCementLayerOptions<T>).internalLayers;
-    return [internalLayers.casingId, internalLayers.cementId];
+    const { internalLayers } = this.options as CasingAndCementLayerOptions<T>;
+    return internalLayers ? [internalLayers.casingId, internalLayers.cementId] : [];
   }
 
   override setVisibility(isVisible: boolean, layerId: string) {

--- a/src/layers/CasingLayer.ts
+++ b/src/layers/CasingLayer.ts
@@ -146,4 +146,8 @@ export class CasingLayer<T extends Casing[]> extends WellboreBaseComponentLayer<
     const textureWidthPO2 = 16;
     return new Texture(Texture.WHITE.baseTexture, null, new Rectangle(0, 0, textureWidthPO2, diameter));
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/CementLayer.ts
+++ b/src/layers/CementLayer.ts
@@ -161,4 +161,8 @@ export class CementLayer<T extends CementData> extends WellboreBaseComponentLaye
 
     return this._textureCache;
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/CompletionLayer.ts
+++ b/src/layers/CompletionLayer.ts
@@ -94,4 +94,8 @@ export class CompletionLayer<T extends CompletionData[]> extends PixiLayer<T> {
   drawCompletionItem(item: CompletionItem): void {
     this.addChild(item.graphics);
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/GeomodelCanvasLayer.ts
+++ b/src/layers/GeomodelCanvasLayer.ts
@@ -173,4 +173,8 @@ export class GeomodelCanvasLayer<T extends SurfaceData> extends CanvasLayer<T> {
 
     return paths;
   };
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/GeomodelLabelsLayer.ts
+++ b/src/layers/GeomodelLabelsLayer.ts
@@ -583,4 +583,8 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
 
     return isLabelsOnLeftSide;
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/GeomodelLayerV2.ts
+++ b/src/layers/GeomodelLayerV2.ts
@@ -107,4 +107,8 @@ export class GeomodelLayerV2<T extends SurfaceData> extends PixiLayer<T> {
     }
     this.addChild(g);
   };
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/GridLayer.ts
+++ b/src/layers/GridLayer.ts
@@ -142,4 +142,8 @@ export class GridLayer<T> extends CanvasLayer<T> {
   set offsetY(offset: number) {
     this._offsetY = offset;
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/HoleSizeLayer.ts
+++ b/src/layers/HoleSizeLayer.ts
@@ -124,4 +124,8 @@ export class HoleSizeLayer<T extends HoleSize[]> extends WellboreBaseComponentLa
 
     return Texture.from(canvas);
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/ImageCanvasLayer.ts
+++ b/src/layers/ImageCanvasLayer.ts
@@ -52,4 +52,8 @@ export class ImageLayer<T> extends CanvasLayer<T> {
       this.ctx.drawImage(this.img, xScale(x || 0), yScale(y || 0), calcWidth, calcHeight);
     }
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/SeismicCanvasLayer.ts
+++ b/src/layers/SeismicCanvasLayer.ts
@@ -43,4 +43,8 @@ export class SeismicCanvasLayer extends CanvasLayer<SeismicCanvasData> {
 
     ctx.drawImage(image, options.x, options.y, options.width, options.height);
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/WellborePathLayer.ts
+++ b/src/layers/WellborePathLayer.ts
@@ -126,4 +126,8 @@ export class WellborepathLayer<T extends [number, number][]> extends SVGLayer<T>
 
     return line().curve(curveFactory)(transformedData);
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/base/HTMLLayer.ts
+++ b/src/layers/base/HTMLLayer.ts
@@ -67,4 +67,8 @@ export abstract class HTMLLayer<T> extends Layer<T> {
       this.elm.style('pointer-events', interactive);
     }
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }

--- a/src/layers/base/Layer.ts
+++ b/src/layers/base/Layer.ts
@@ -156,7 +156,7 @@ export abstract class Layer<T> {
     this.onUpdate({});
   }
 
-  setVisibility(visible: boolean): void {
+  setVisibility(visible: boolean, _layerId?: string): void {
     this._visible = visible;
   }
 
@@ -203,4 +203,6 @@ export abstract class Layer<T> {
   abstract onOrderChanged(order: number): void;
 
   abstract onInteractivityChanged(interactive: boolean): void;
+
+  abstract getInternalLayerIds(): string[];
 }

--- a/src/layers/base/PixiLayer.ts
+++ b/src/layers/base/PixiLayer.ts
@@ -148,8 +148,8 @@ export abstract class PixiLayer<T> extends Layer<T> {
     this.pixiViewContainer.setAttribute('style', `position:absolute;pointer-events:${interactive};z-index:${this.order};opacity:${this.opacity};`);
   }
 
-  setVisibility(visible: boolean): void {
-    super.setVisibility(visible);
+  setVisibility(visible: boolean, layerId?: string): void {
+    super.setVisibility(visible, layerId);
     if (this.pixiViewContainer) {
       this.updateStyle(visible);
     }

--- a/test/layer.test.ts
+++ b/test/layer.test.ts
@@ -20,6 +20,10 @@ class TestLayer extends Layer<string> {
   onUpdate(_event: OnUpdateEvent<string>) {
     this.updateWasCalled = true;
   }
+
+  getInternalLayerIds(): string[] {
+    return [];
+  }
 }
 
 const data = 'test';


### PR DESCRIPTION
Part of the esv-improvement-efforts is to merge all pixi layers into one. With that comes the need to update how visibility can toggle to show different parts of the well.

This PR lets users have a internal layer options so that CasingAndCement can show/hide casings and cements seperately.