### PR TITLE
fix: flip wellbore textures

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,8 +4,8 @@ export const DEFAULT_LAYER_HEIGHT = 300;
 export const HORIZONTAL_AXIS_MARGIN = 40;
 export const VERTICAL_AXIS_MARGIN = 30;
 
-export const HOLE_OUTLINE = 0.5;
-export const SCREEN_OUTLINE = 0.5;
+export const HOLE_OUTLINE = 0.6;
+export const SCREEN_OUTLINE = 0.3;
 export const SHOE_WIDTH = 25;
 export const SHOE_LENGTH = 12;
 

--- a/src/layers/ImageComponentLayer.ts
+++ b/src/layers/ImageComponentLayer.ts
@@ -1,4 +1,4 @@
-import { Point, Rectangle, RENDERER_TYPE, Texture } from 'pixi.js';
+import { Point, Rectangle, RENDERER_TYPE, Texture, groupD8 } from 'pixi.js';
 import { WellboreBaseComponentLayer, WellComponentBaseOptions } from './WellboreBaseComponentLayer';
 import { PixiRenderApplication } from '..';
 import { UniformTextureStretchRope } from './CustomDisplayObjects/UniformTextureStretchRope';
@@ -97,7 +97,7 @@ export class ImageComponentLayer<T extends ImageComponent[]> extends WellboreBas
   }
 
   createTexture(imageKey: string, diameter: number): Texture {
-    return new Texture(this._textureCacheArray[imageKey].baseTexture, null, new Rectangle(0, 0, 0, diameter), null, 2);
+    return new Texture(this._textureCacheArray[imageKey].baseTexture, null, new Rectangle(0, 0, 0, diameter), null, groupD8.MAIN_DIAGONAL);
   }
 
   getInternalLayerIds(): string[] {


### PR DESCRIPTION
- we are drawing textures from top down along the wellbore and therefore have to flip and mirror the texture
- adjust hole outline and screen outline thickness