### PR TITLE
Use referenceIds instead of casingIds

### DIFF
--- a/.storybook/src/complete-example/intersection.stories.ts
+++ b/.storybook/src/complete-example/intersection.stories.ts
@@ -169,6 +169,7 @@ const renderIntersection = (scaleOptions: any) => {
         diameter: 8.5,
         symbolKey: 'mechanicalPlug',
       },
+      { kind: 'cementPlug' as const, id: 'cement-plug-2', start: 5000, end: 5110, referenceIds: ['casing-07'] },
     ];
 
     const schematicData: SchematicData = {
@@ -239,7 +240,7 @@ const renderIntersection = (scaleOptions: any) => {
       ['Cement', internalLayerIds.cementLayerId],
       ['Completion', internalLayerIds.completionLayerId],
       ['Plug & Abandonment', internalLayerIds.pAndALayerId],
-    ].map(([description, internalLayerId]) => createInternalLayerVisibilityButton(controller, internalLayerId, description))
+    ].map(([description, internalLayerId]) => createInternalLayerVisibilityButton(controller, internalLayerId, description));
 
     let show = true;
     const toggleAxis = createButtonWithCb(

--- a/.storybook/src/complete-example/intersection.stories.ts
+++ b/.storybook/src/complete-example/intersection.stories.ts
@@ -1,4 +1,3 @@
-import { IntersectionReferenceSystem, Controller } from '../../../src/control';
 import {
   GridLayer,
   WellborepathLayer,
@@ -8,11 +7,6 @@ import {
   SeismicCanvasLayer,
   CalloutCanvasLayer,
   PixiRenderApplication,
-} from '../../../src/layers';
-
-import { createButtonContainer, createFPSLabel, createLayerContainer, createRootContainer, createHelpText } from '../utils';
-
-import {
   generateSurfaceData,
   SurfaceData,
   getSeismicInfo,
@@ -20,7 +14,17 @@ import {
   transformFormationData,
   getPicksData,
   getSeismicOptions,
-} from '../../../src/datautils';
+  IntersectionReferenceSystem,
+  Controller,
+  Annotation,
+  SchematicLayer,
+  SchematicLayerOptions,
+  InternalLayerOptions,
+  Perforation,
+  SchematicData,
+} from '../../../src';
+
+import { createButtonContainer, createFPSLabel, createLayerContainer, createRootContainer, createHelpText } from '../utils';
 
 //Data
 import { seismicColorMap } from '../exampledata';
@@ -37,8 +41,6 @@ import {
   getCompletion,
   getCementSqueezes,
 } from '../data';
-import { Annotation, SchematicLayer, SchematicLayerOptions } from '../../../src';
-import { InternalLayerOptions, SchematicData } from '../../../src/layers/schematicInterfaces';
 
 export const intersection = () => {
   const xBounds: [number, number] = [0, 1000];
@@ -172,12 +174,34 @@ const renderIntersection = (scaleOptions: any) => {
       { kind: 'cementPlug' as const, id: 'cement-plug-2', start: 5000, end: 5110, referenceIds: ['casing-07'] },
     ];
 
+    const perforations: Perforation[] = [
+      {
+        kind: 'perforation',
+        subKind: 'Perforation',
+        id: 'PerforationDemo1',
+        start: 4000,
+        end: 4500,
+        isOpen: true,
+        referenceIds: ['casing-07'],
+      },
+      {
+        kind: 'perforation',
+        subKind: 'Cased hole frac pack',
+        id: 'PerforationDemo2',
+        start: 3500,
+        end: 4500,
+        isOpen: true,
+        referenceIds: ['casing-07'],
+      },
+    ];
+
     const schematicData: SchematicData = {
       holeSizes,
       cements: cement,
       casings,
       completion: [...completion, ...completionSymbols],
       pAndA: [...pAndASymbols, ...cementSqueezes],
+      perforations,
       symbols: { ...CSDSVGs, ...pAndASVGs },
     };
 
@@ -187,6 +211,7 @@ const renderIntersection = (scaleOptions: any) => {
       completionLayerId: 'completion-id',
       cementLayerId: 'cement-id',
       pAndALayerId: 'pAndA-id',
+      perforationLayerId: 'perforation-id',
     };
 
     const schematicLayerOptions: SchematicLayerOptions<SchematicData> = {
@@ -240,6 +265,7 @@ const renderIntersection = (scaleOptions: any) => {
       ['Cement', internalLayerIds.cementLayerId],
       ['Completion', internalLayerIds.completionLayerId],
       ['Plug & Abandonment', internalLayerIds.pAndALayerId],
+      ['Perforations', internalLayerIds.perforationLayerId],
     ].map(([description, internalLayerId]) => createInternalLayerVisibilityButton(controller, internalLayerId, description));
 
     let show = true;

--- a/.storybook/src/features/schematic-layer.stories.ts
+++ b/.storybook/src/features/schematic-layer.stories.ts
@@ -7,6 +7,9 @@ import {
   Perforation,
   InternalLayerOptions,
   SchematicData,
+  PAndASymbol,
+  CementPlug,
+  CompletionSymbol,
 } from '../../../src';
 
 import { createRootContainer, createLayerContainer, createFPSLabel, createHelpText, createButtonContainer } from '../utils';
@@ -35,7 +38,7 @@ export const SchematicLayerUsingHighLevelInterface = () => {
           'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0xMCAwSDkwVjEwMEgxMFYwWiIgZmlsbD0iI0Q5RDlEOSIvPgo8cGF0aCBkPSJNMCAyNUgxMFY3NUgwVjI1WiIgZmlsbD0iI0I1QjJCMiIvPgo8cGF0aCBkPSJNNDUgMjVINTVWNzVINDVWMjVaIiBmaWxsPSIjQjVCMkIyIi8+CjxwYXRoIGQ9Ik0yNSA2NUgzMFY4MEgyNVY2NVoiIGZpbGw9IiMzMTMxMzEiLz4KPHBhdGggZD0iTTI1IDQySDMwVjU3SDI1VjQyWiIgZmlsbD0iIzMxMzEzMSIvPgo8cGF0aCBkPSJNMjUgMjFIMzBWMzZIMjVWMjFaIiBmaWxsPSIjMzEzMTMxIi8+CjxwYXRoIGQ9Ik03MCA2NEg3NVY3OUg3MFY2NFoiIGZpbGw9IiMzMTMxMzEiLz4KPHBhdGggZD0iTTcwIDQxSDc1VjU2SDcwVjQxWiIgZmlsbD0iIzMxMzEzMSIvPgo8cGF0aCBkPSJNNzAgMjBINzVWMzVINzBWMjBaIiBmaWxsPSIjMzEzMTMxIi8+CjxwYXRoIGQ9Ik05MCAyNUgxMDBWNzVIOTBWMjVaIiBmaWxsPSIjQjVCMkIyIi8+Cjwvc3ZnPgo=',
       };
 
-      const completionSymbols = [
+      const completionSymbols: CompletionSymbol[] = [
         {
           kind: 'completionSymbol',
           id: 'completion-svg-1',
@@ -68,7 +71,7 @@ export const SchematicLayerUsingHighLevelInterface = () => {
       };
 
       const pAndASymbols = [
-        {
+        <PAndASymbol>{
           kind: 'pAndASymbol' as const,
           id: 'mechanical-plug-1',
           start: 5100,
@@ -76,7 +79,7 @@ export const SchematicLayerUsingHighLevelInterface = () => {
           diameter: 8.5,
           symbolKey: 'mechanicalPlug',
         },
-        { kind: 'cementPlug' as const, id: 'cement-plug-2', top: 5000, bottom: 5110, casingId: '7' },
+        <CementPlug>{ kind: 'cementPlug' as const, id: 'cement-plug-2', start: 5000, end: 5110, referenceIds: ['casing-07'] },
       ];
 
       const perforations: Perforation[] = [
@@ -84,8 +87,8 @@ export const SchematicLayerUsingHighLevelInterface = () => {
           kind: 'perforation',
           subKind: 'Perforation',
           id: 'PerforationDemo1',
-          top: 4000,
-          bottom: 4500,
+          start: 4000,
+          end: 4500,
           isOpen: true,
           referenceIds: ['casing-07'],
         },
@@ -93,8 +96,8 @@ export const SchematicLayerUsingHighLevelInterface = () => {
           kind: 'perforation',
           subKind: 'Cased hole frac pack',
           id: 'PerforationDemo2',
-          top: 3500,
-          bottom: 4500,
+          start: 3500,
+          end: 4500,
           isOpen: true,
           referenceIds: ['casing-07'],
         },

--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -137,7 +137,7 @@ export class LayerManager {
   showLayer(layerId: string): LayerManager {
     const layer = this.getLayer(layerId);
     if (!layer) {
-      return;
+      return this;
     }
     layer.setVisibility(true, layerId);
     layer.onRescale(this.zoomPanHandler.currentStateAsEvent());
@@ -147,7 +147,7 @@ export class LayerManager {
   hideLayer(layerId: string): LayerManager {
     const layer = this.getLayer(layerId);
     if (!layer) {
-      return;
+      return this;
     }
     layer.setVisibility(false, layerId);
     layer.onRescale(this.zoomPanHandler.currentStateAsEvent());

--- a/src/datautils/schematicShapeGenerator.ts
+++ b/src/datautils/schematicShapeGenerator.ts
@@ -151,7 +151,7 @@ export const findCementInnerDiameterAtDepth = (
     return getInnerStringDiameter(attachedStringAtDepth);
   }
 
-  // Guarantee an attached diameter
+  // Start from an attached diameter
   const minimumDiameter = attachedStrings.length ? Math.min(...attachedStrings.map((c) => getInnerStringDiameter(c))) : 0;
   const nonAttachedStringAtDepth = nonAttachedStrings
     .sort((a: Casing | Completion, b: Casing | Completion) => getInnerStringDiameter(a) - getInnerStringDiameter(b)) // ascending
@@ -282,15 +282,15 @@ export const createComplexRopeSegmentsForCementSqueeze = (
   const changeDepths = getUniqueDiameterChangeDepths([squeeze.start, squeeze.end], outerDiameterIntervals);
 
   const diameterIntervals = changeDepths.flatMap((depth, index, list) => {
-    if (index === 0) {
+    if (index === list.length - 1) {
       return [];
     }
 
-    const nextDepth = list[index - 1];
+    const nextDepth = list[index + 1];
 
-    const diameter = findCementOuterDiameterAtDepth(attachedStrings, overlappingOuterStrings, overlappingHoles, depth) * exaggerationFactor;
+    const diameterAtDepth = findCementOuterDiameterAtDepth(attachedStrings, overlappingOuterStrings, overlappingHoles, depth);
 
-    return [{ top: nextDepth, bottom: depth, diameter }];
+    return [{ top: depth, bottom: nextDepth, diameter: diameterAtDepth * exaggerationFactor }];
   });
 
   const ropeSegments = diameterIntervals.map((interval) => {

--- a/src/datautils/schematicShapeGenerator.ts
+++ b/src/datautils/schematicShapeGenerator.ts
@@ -316,10 +316,6 @@ export const createComplexRopeSegmentsForCementPlug = (
 ): ComplexRopeSegment[] => {
   const { attachedStrings, nonAttachedStrings } = splitByReferencedStrings(plug.referenceIds, casings, completion);
 
-  if (attachedStrings.length === 0) {
-    throw new Error(`Invalid cement plug data, can't find referenced casing/completion for plug with id '${plug.id}'`);
-  }
-
   const { overlappingHoles, overlappingOuterStrings } = findIntersectingItems(plug.start, plug.end, nonAttachedStrings, holes);
   const innerDiameterIntervals = [...attachedStrings, ...overlappingHoles, ...overlappingOuterStrings].map((d) => ({
     start: d.start,

--- a/src/datautils/schematicShapeGenerator.ts
+++ b/src/datautils/schematicShapeGenerator.ts
@@ -82,7 +82,7 @@ const findIntersectingItems = (
   };
 };
 
-const getUniqueDiameterChangeDepths = (
+export const getUniqueDiameterChangeDepths = (
   [intervalStart, intervalEnd]: [number, number],
   diameterIntervals: { start: number; end: number }[],
 ): number[] => {
@@ -135,7 +135,7 @@ export const findCementOuterDiameterAtDepth = (
   return defaultCementWidth;
 };
 
-export const findCementInnerDiameterAtDepth = (
+export const findCementPlugInnerDiameterAtDepth = (
   attachedStrings: (Casing | Completion)[],
   nonAttachedStrings: (Casing | Completion)[],
   holes: HoleSize[],
@@ -330,7 +330,7 @@ export const createComplexRopeSegmentsForCementPlug = (
     }
 
     const nextDepth = list[index + 1];
-    const diameterAtDepth = findCementInnerDiameterAtDepth(attachedStrings, overlappingOuterStrings, overlappingHoles, depth);
+    const diameterAtDepth = findCementPlugInnerDiameterAtDepth(attachedStrings, overlappingOuterStrings, overlappingHoles, depth);
 
     return [{ top: depth, bottom: nextDepth, diameter: diameterAtDepth * exaggerationFactor }];
   });

--- a/src/datautils/schematicShapeGenerator.ts
+++ b/src/datautils/schematicShapeGenerator.ts
@@ -7,6 +7,8 @@ import {
   CementPlug,
   CementPlugOptions,
   CementSqueeze,
+  CementSqueezeOptions,
+  Completion,
   HoleOptions,
   HoleSize,
   ScreenOptions,
@@ -26,6 +28,7 @@ import { createNormals, offsetPoints } from '../utils/vectorUtils';
 export type PerforationShape = ComplexRopeSegment;
 
 export interface TubularRenderingObject {
+  id: string;
   leftPath: Point[];
   rightPath: Point[];
   referenceDiameter: number;
@@ -36,7 +39,6 @@ export interface CasingRenderObject extends TubularRenderingObject {
   kind: 'casing';
   pathPoints: number[][];
   polygon: Point[];
-  casingId: string;
   casingWallWidth: number;
   hasShoe: boolean;
   bottom: number;
@@ -64,59 +66,66 @@ export const overlaps = (top1: number, bottom1: number, top2: number, bottom2: n
 
 export const uniq = <T>(arr: T[]): T[] => Array.from<T>(new Set(arr));
 
-export const findIntersectingItems = (
-  topOfCement: number,
-  bottomOfCement: number,
-  parentCasings: Casing[],
-  casings: Casing[],
+const findIntersectingItems = (
+  start: number,
+  end: number,
+  otherStrings: (Casing | Completion)[],
   holes: HoleSize[],
-): { overlappingHoles: HoleSize[]; outerCasings: Casing[] } => {
-  const overlappingHoles = holes.filter((h: HoleSize) => overlaps(topOfCement, bottomOfCement, h.start, h.end));
+): { overlappingHoles: HoleSize[]; overlappingOuterStrings: (Casing | Completion)[] } => {
+  const overlappingHoles = holes.filter((hole: HoleSize) => overlaps(start, end, hole.start, hole.end));
 
-  const otherCasings = casings.filter((c: Casing) => !parentCasings.includes(c));
-  const overlappingCasings = otherCasings.filter((c: Casing) => overlaps(topOfCement, bottomOfCement, c.start, c.end));
+  const overlappingOuterStrings = otherStrings.filter((casing: Casing | Completion) => overlaps(start, end, casing.start, casing.end));
 
   return {
     overlappingHoles,
-    outerCasings: overlappingCasings,
+    overlappingOuterStrings,
   };
 };
 
-export const cementDiameterChangeDepths = (
-  cement: Cement,
-  bottomOfCement: number,
-  diameterIntervals: {
-    start: number;
-    end: number;
-  }[],
+const getUniqueDiameterChangeDepths = (
+  [intervalStart, intervalEnd]: [number, number],
+  diameterIntervals: { start: number; end: number }[],
 ): number[] => {
-  const topOfCement = cement.toc;
+  const epsilon = 0.0001;
+  const diameterChangeDepths = diameterIntervals.flatMap(
+    (
+      d, // to find diameter right before/after object
+    ) => [d.start - epsilon, d.start, d.end, d.end + epsilon],
+  );
+  const trimmedChangedDepths = diameterChangeDepths.filter((d) => d >= intervalStart && d <= intervalEnd); // trim
 
-  const diameterChangeDepths = diameterIntervals.flatMap((d) => [d.start, d.end]);
-  const trimmedChangedDepths = diameterChangeDepths.filter((d) => d >= topOfCement && d <= bottomOfCement); // trim
-
-  trimmedChangedDepths.push(topOfCement);
-  trimmedChangedDepths.push(bottomOfCement);
+  trimmedChangedDepths.push(intervalStart);
+  trimmedChangedDepths.push(intervalEnd);
 
   const uniqDepths = uniq(trimmedChangedDepths);
-
   return uniqDepths.sort((a: number, b: number) => a - b);
 };
 
-export const findCementOuterDiameterAtDepth = (innerCasing: Casing[], nonAttachedCasings: Casing[], holes: HoleSize[], depth: number): number => {
+const getInnerStringDiameter = (stringType: Casing | Completion): number =>
+  stringType.kind === 'casing' ? stringType.innerDiameter : stringType.diameter;
+
+export const findCementOuterDiameterAtDepth = (
+  attachedStrings: (Casing | Completion)[],
+  nonAttachedStrings: (Casing | Completion)[],
+  holes: HoleSize[],
+  depth: number,
+): number => {
   const defaultCementWidth = 100; // Default to flow cement outside to show error in data
 
-  const innerCasingAtDepth = innerCasing.find((casing) => casing.start <= depth && casing.end >= depth);
-  const innerDiameter = innerCasingAtDepth ? innerCasingAtDepth.diameter : 0;
+  const attachedStringAtDepth = attachedStrings.find(
+    (casingOrCompletion: Casing | Completion) => casingOrCompletion.start <= depth && casingOrCompletion.end >= depth,
+  );
+  const attachedOuterDiameter = attachedStringAtDepth ? attachedStringAtDepth.diameter : 0;
 
-  const outerCasings = nonAttachedCasings.filter((casing) => casing.innerDiameter > innerDiameter);
-  const holeAtDepth = holes.find((hole) => hole.start <= depth && hole.end >= depth && hole.diameter > innerDiameter);
-  const outerCasingAtDepth = outerCasings
-    .sort((a, b) => a.innerDiameter - b.innerDiameter) // ascending
-    .find((casing) => casing.start <= depth && casing.end >= depth && casing.diameter > innerDiameter);
+  const outerCasingAtDepth = nonAttachedStrings
+    .filter((casingOrCompletion: Casing | Completion) => getInnerStringDiameter(casingOrCompletion) > attachedOuterDiameter)
+    .sort((a: Casing | Completion, b: Casing | Completion) => getInnerStringDiameter(a) - getInnerStringDiameter(b)) // ascending
+    .find((casing) => casing.start <= depth && casing.end >= depth);
+
+  const holeAtDepth = holes.find((hole: HoleSize) => hole.start <= depth && hole.end >= depth && hole.diameter > attachedOuterDiameter);
 
   if (outerCasingAtDepth) {
-    return outerCasingAtDepth.innerDiameter;
+    return getInnerStringDiameter(outerCasingAtDepth);
   }
 
   if (holeAtDepth) {
@@ -126,57 +135,79 @@ export const findCementOuterDiameterAtDepth = (innerCasing: Casing[], nonAttache
   return defaultCementWidth;
 };
 
-export const findCementInnerDiameterAtDepth = (innerCasing: Casing[], _nonAttachedCasings: Casing[], holes: HoleSize[], depth: number): number => {
-  const innerCasingAtDepth = innerCasing.find((casing) => casing.start <= depth && casing.end >= depth);
-  const innerDiameter = innerCasingAtDepth ? innerCasingAtDepth.innerDiameter : 0;
+export const findCementInnerDiameterAtDepth = (
+  attachedStrings: (Casing | Completion)[],
+  nonAttachedStrings: (Casing | Completion)[],
+  holes: HoleSize[],
+  depth: number,
+): number => {
+  // Default to flow cement outside to show error in data
+  const defaultCementWidth = 100;
+  const attachedStringAtDepth = attachedStrings
+    .sort((a: Casing | Completion, b: Casing | Completion) => getInnerStringDiameter(a) - getInnerStringDiameter(b)) // ascending
+    .find((casingOrCompletion) => casingOrCompletion.start <= depth && casingOrCompletion.end >= depth);
 
-  const holeAtDepth = holes.find((hole) => hole.start <= depth && hole.end >= depth && hole.diameter > innerDiameter);
-
-  if (innerCasingAtDepth) {
-    return innerDiameter;
+  if (attachedStringAtDepth) {
+    return getInnerStringDiameter(attachedStringAtDepth);
   }
+
+  // Guarantee an attached diameter
+  const minimumDiameter = attachedStrings.length ? Math.min(...attachedStrings.map((c) => getInnerStringDiameter(c))) : 0;
+  const nonAttachedStringAtDepth = nonAttachedStrings
+    .sort((a: Casing | Completion, b: Casing | Completion) => getInnerStringDiameter(a) - getInnerStringDiameter(b)) // ascending
+    .find(
+      (casingOrCompletion: Casing | Completion) =>
+        casingOrCompletion.start <= depth && casingOrCompletion.end >= depth && minimumDiameter <= getInnerStringDiameter(casingOrCompletion),
+    );
+
+  if (nonAttachedStringAtDepth) {
+    return getInnerStringDiameter(nonAttachedStringAtDepth);
+  }
+
+  const holeAtDepth = holes.find((hole) => hole.start <= depth && hole.end >= depth && hole.diameter);
 
   if (holeAtDepth) {
     return holeAtDepth.diameter;
   }
+
+  return defaultCementWidth;
 };
 
 export const createComplexRopeSegmentsForCement = (
   cement: Cement,
   casings: Casing[],
+  completion: Completion[],
   holes: HoleSize[],
   exaggerationFactor: number,
   getPoints: (start: number, end: number) => [number, number][],
 ): ComplexRopeSegment[] => {
-  const casingIds = (cement.casingIds || []).filter((id) => id);
+  const { attachedStrings, nonAttachedStrings } = splitByReferencedStrings(cement.referenceIds, casings, completion);
 
-  const attachedCasings = casingIds.map((casingId) => casings.find((casing) => casing.casingId === casingId));
-  if (attachedCasings.length === 0 || attachedCasings.includes(undefined)) {
-    throw new Error('Invalid cement data, cement is missing attached casing');
+  if (attachedStrings.length === 0) {
+    throw new Error(`Invalid cement data, can't find referenced casing/completion string for cement with id '${cement.id}'`);
   }
 
-  const topOfCement = cement.toc;
-  attachedCasings.sort((a: Casing, b: Casing) => a.end - b.end); // ascending
-  const bottomOfCement = attachedCasings[attachedCasings.length - 1].end;
+  attachedStrings.sort((a: Casing, b: Casing) => a.end - b.end); // ascending
+  const bottomOfCement = attachedStrings[attachedStrings.length - 1].end;
 
-  const { outerCasings, overlappingHoles } = findIntersectingItems(topOfCement, bottomOfCement, attachedCasings, casings, holes);
+  const { overlappingOuterStrings, overlappingHoles } = findIntersectingItems(cement.toc, bottomOfCement, nonAttachedStrings, holes);
 
-  const outerDiameterIntervals = [...outerCasings, ...overlappingHoles].map((d) => ({
+  const outerDiameterIntervals = [...overlappingOuterStrings, ...overlappingHoles].map((d) => ({
     start: d.start,
     end: d.end,
   }));
 
-  const changeDepths = cementDiameterChangeDepths(cement, bottomOfCement, outerDiameterIntervals);
+  const changeDepths = getUniqueDiameterChangeDepths([cement.toc, bottomOfCement], outerDiameterIntervals);
 
   const diameterIntervals = changeDepths.flatMap((depth: number, index: number, list: number[]) => {
-    if (index === 0) {
+    if (index === list.length - 1) {
       return [];
     }
 
-    const nextDepth = list[index - 1];
-    const diameter = findCementOuterDiameterAtDepth(attachedCasings, outerCasings, overlappingHoles, depth) * exaggerationFactor;
+    const nextDepth = list[index + 1];
+    const diameterAtChangeDepth = findCementOuterDiameterAtDepth(attachedStrings, overlappingOuterStrings, overlappingHoles, depth);
 
-    return [{ top: nextDepth, bottom: depth, diameter }];
+    return [{ top: depth, bottom: nextDepth, diameter: diameterAtChangeDepth * exaggerationFactor }];
   });
 
   const ropeSegments = diameterIntervals.map((interval) => {
@@ -192,45 +223,20 @@ export const createComplexRopeSegmentsForCement = (
   return ropeSegments;
 };
 
-export const cementSqueezeDiameterChangeDepths = (
-  squeeze: CementSqueeze,
-  diameterIntervals: {
-    start: number;
-    end: number;
-  }[],
-): number[] => {
-  const { top: topOfCement, bottom: bottomOfCement } = squeeze;
-
-  const diameterChangeDepths = diameterIntervals.flatMap((d) => [d.start, d.end]);
-  const trimmedChangedDepths = diameterChangeDepths.filter((d) => d >= topOfCement && d <= bottomOfCement); // trim
-
-  trimmedChangedDepths.push(topOfCement);
-  trimmedChangedDepths.push(bottomOfCement);
-
-  const uniqDepths = uniq(trimmedChangedDepths);
-
-  return uniqDepths.sort((a: number, b: number) => a - b);
-};
-
-export const cementPlugDiameterChangeDepths = (
-  plug: CementPlug,
-  diameterIntervals: {
-    start: number;
-    end: number;
-  }[],
-): number[] => {
-  const { top: topOfCement, bottom: bottomOfCement } = plug;
-
-  const diameterChangeDepths = diameterIntervals.flatMap((d) => [d.start, d.end]);
-  const trimmedChangedDepths = diameterChangeDepths.filter((d) => d >= topOfCement && d <= bottomOfCement); // trim
-
-  trimmedChangedDepths.push(topOfCement);
-  trimmedChangedDepths.push(bottomOfCement);
-
-  const uniqDepths = uniq(trimmedChangedDepths);
-
-  return uniqDepths.sort((a: number, b: number) => a - b);
-};
+const splitByReferencedStrings = (
+  referenceIds: string[],
+  casings: Casing[],
+  completion: Completion[],
+): { attachedStrings: (Casing | Completion)[]; nonAttachedStrings: (Casing | Completion)[] } =>
+  [...casings, ...completion].reduce(
+    (acc, current) => {
+      if (referenceIds.includes(current.id)) {
+        return { ...acc, attachedStrings: [...acc.attachedStrings, current] };
+      }
+      return { ...acc, nonAttachedStrings: [...acc.nonAttachedStrings, current] };
+    },
+    { attachedStrings: [], nonAttachedStrings: [] },
+  );
 
 export const perforationDiameterChangeDepths = (
   perforation: Perforation,
@@ -239,7 +245,7 @@ export const perforationDiameterChangeDepths = (
     end: number;
   }[],
 ): number[] => {
-  const { top: topOfPerforation, bottom: bottomOfPerforation } = perforation;
+  const { start: topOfPerforation, end: bottomOfPerforation } = perforation;
 
   const diameterChangeDepths = diameterIntervals.flatMap((d) => [d.start, d.end]);
   const trimmedChangedDepths = diameterChangeDepths.filter((d) => d >= topOfPerforation && d <= bottomOfPerforation); // trim
@@ -255,25 +261,25 @@ export const perforationDiameterChangeDepths = (
 export const createComplexRopeSegmentsForCementSqueeze = (
   squeeze: CementSqueeze,
   casings: Casing[],
+  completion: Completion[],
   holes: HoleSize[],
   exaggerationFactor: number,
   getPoints: (start: number, end: number) => [number, number][],
 ): ComplexRopeSegment[] => {
-  const { casingIds, top: topOfCement, bottom: bottomOfCement } = squeeze;
+  const { attachedStrings, nonAttachedStrings } = splitByReferencedStrings(squeeze.referenceIds, casings, completion);
 
-  const attachedCasings = casingIds.map((casingId) => casings.find((casing) => casing.casingId === casingId));
-  if (attachedCasings.length === 0 || attachedCasings.includes(undefined)) {
-    throw new Error('Invalid cement squeeze data, cement is missing attached casing');
+  if (attachedStrings.length === 0) {
+    throw new Error(`Invalid cement squeeze data, can't find referenced casing/completion for squeeze with id '${squeeze.id}'`);
   }
 
-  const { outerCasings, overlappingHoles } = findIntersectingItems(topOfCement, bottomOfCement, attachedCasings, casings, holes);
+  const { overlappingOuterStrings, overlappingHoles } = findIntersectingItems(squeeze.start, squeeze.end, nonAttachedStrings, holes);
 
-  const outerDiameterIntervals = [...outerCasings, ...overlappingHoles].map((d) => ({
+  const outerDiameterIntervals = [...overlappingOuterStrings, ...overlappingHoles].map((d) => ({
     start: d.start,
     end: d.end,
   }));
 
-  const changeDepths = cementSqueezeDiameterChangeDepths(squeeze, outerDiameterIntervals);
+  const changeDepths = getUniqueDiameterChangeDepths([squeeze.start, squeeze.end], outerDiameterIntervals);
 
   const diameterIntervals = changeDepths.flatMap((depth, index, list) => {
     if (index === 0) {
@@ -282,7 +288,7 @@ export const createComplexRopeSegmentsForCementSqueeze = (
 
     const nextDepth = list[index - 1];
 
-    const diameter = findCementOuterDiameterAtDepth(attachedCasings, outerCasings, overlappingHoles, depth) * exaggerationFactor;
+    const diameter = findCementOuterDiameterAtDepth(attachedStrings, overlappingOuterStrings, overlappingHoles, depth) * exaggerationFactor;
 
     return [{ top: nextDepth, bottom: depth, diameter }];
   });
@@ -303,33 +309,34 @@ export const createComplexRopeSegmentsForCementSqueeze = (
 export const createComplexRopeSegmentsForCementPlug = (
   plug: CementPlug,
   casings: Casing[],
+  completion: Completion[],
   holes: HoleSize[],
   exaggerationFactor: number,
   getPoints: (start: number, end: number) => [number, number][],
 ): ComplexRopeSegment[] => {
-  const { casingId, secondCasingId, top: topOfCementPlug, bottom: bottomOfCementPlug } = plug;
+  const { attachedStrings, nonAttachedStrings } = splitByReferencedStrings(plug.referenceIds, casings, completion);
 
-  const attachedCasings = [casings.find((c) => c.casingId === casingId), casings.find((c) => c.casingId === secondCasingId)].filter((c) => c);
-  if (attachedCasings.length === 0 || attachedCasings.includes(undefined)) {
-    throw new Error('Invalid cement plug data, cement plug is missing attached casing');
+  if (attachedStrings.length === 0) {
+    throw new Error(`Invalid cement plug data, can't find referenced casing/completion for plug with id '${plug.id}'`);
   }
-  const { overlappingHoles } = findIntersectingItems(topOfCementPlug, bottomOfCementPlug, attachedCasings, casings, holes);
-  const innerDiameterIntervals = [...attachedCasings, ...overlappingHoles].map((d) => ({
+
+  const { overlappingHoles, overlappingOuterStrings } = findIntersectingItems(plug.start, plug.end, nonAttachedStrings, holes);
+  const innerDiameterIntervals = [...attachedStrings, ...overlappingHoles, ...overlappingOuterStrings].map((d) => ({
     start: d.start,
     end: d.end,
   }));
 
-  const changeDepths = cementPlugDiameterChangeDepths(plug, innerDiameterIntervals);
+  const changeDepths = getUniqueDiameterChangeDepths([plug.start, plug.end], innerDiameterIntervals);
 
   const diameterIntervals = changeDepths.flatMap((depth, index, list) => {
-    if (index === 0) {
+    if (index === list.length - 1) {
       return [];
     }
 
-    const nextDepth = list[index - 1];
-    const diameter = findCementInnerDiameterAtDepth(attachedCasings, attachedCasings, overlappingHoles, depth) * exaggerationFactor;
+    const nextDepth = list[index + 1];
+    const diameterAtDepth = findCementInnerDiameterAtDepth(attachedStrings, overlappingOuterStrings, overlappingHoles, depth);
 
-    return [{ top: nextDepth, bottom: depth, diameter }];
+    return [{ top: depth, bottom: nextDepth, diameter: diameterAtDepth * exaggerationFactor }];
   });
 
   const ropeSegments = diameterIntervals.map((interval) => {
@@ -420,7 +427,7 @@ export const createTubingTexture = ({ innerColor, outerColor, scalingFactor }: T
   return Texture.from(canvas);
 };
 
-export const createCementTexture = ({ firstColor, secondColor, scalingFactor }: CementOptions) => {
+export const createCementTexture = ({ firstColor, secondColor, scalingFactor }: CementOptions): Texture => {
   const canvas = document.createElement('canvas');
 
   const size = DEFAULT_TEXTURE_SIZE * scalingFactor;
@@ -445,7 +452,7 @@ export const createCementTexture = ({ firstColor, secondColor, scalingFactor }: 
   return Texture.from(canvas);
 };
 
-export const createCementPlugTexture = ({ firstColor, secondColor, scalingFactor }: CementPlugOptions) => {
+export const createCementPlugTexture = ({ firstColor, secondColor, scalingFactor }: CementPlugOptions): Texture => {
   const canvas = document.createElement('canvas');
 
   const size = DEFAULT_TEXTURE_SIZE * scalingFactor;
@@ -456,7 +463,7 @@ export const createCementPlugTexture = ({ firstColor, secondColor, scalingFactor
   canvasCtx.fillStyle = firstColor;
   canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
   canvasCtx.lineWidth = scalingFactor;
-  canvasCtx.fillStyle = secondColor;
+  canvasCtx.strokeStyle = secondColor;
   canvasCtx.beginPath();
 
   canvasCtx.setLineDash([20, 10]); // eslint-disable-line no-magic-numbers
@@ -470,21 +477,48 @@ export const createCementPlugTexture = ({ firstColor, secondColor, scalingFactor
   return Texture.from(canvas);
 };
 
-export const createTubularRenderingObject = (diameter: number, pathPoints: [number, number][]): TubularRenderingObject => {
+export const createCementSqueezeTexture = ({ firstColor, secondColor, scalingFactor }: CementSqueezeOptions): Texture => {
+  const canvas = document.createElement('canvas');
+
+  const size = DEFAULT_TEXTURE_SIZE * scalingFactor;
+  const lineWidth = scalingFactor;
+  canvas.width = size;
+  canvas.height = size;
+
+  const canvasCtx = canvas.getContext('2d');
+  canvasCtx.lineWidth = lineWidth;
+  canvasCtx.fillStyle = firstColor;
+  canvasCtx.strokeStyle = secondColor;
+
+  canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
+  canvasCtx.beginPath();
+
+  canvasCtx.setLineDash([20, 10]); // eslint-disable-line no-magic-numbers
+  const distanceBetweenLines = size / 12; // eslint-disable-line no-magic-numbers
+  for (let i = -canvas.width; i < canvas.width; i++) {
+    canvasCtx.moveTo(-canvas.width + distanceBetweenLines * i, -canvas.height);
+    canvasCtx.lineTo(canvas.width + distanceBetweenLines * i, canvas.height * 2);
+  }
+  canvasCtx.stroke();
+
+  return Texture.from(canvas);
+};
+
+export const createTubularRenderingObject = (id: string, diameter: number, pathPoints: [number, number][]): TubularRenderingObject => {
   const radius = diameter / 2;
 
   const normals = createNormals(pathPoints);
   const rightPath = offsetPoints(pathPoints, normals, radius);
   const leftPath = offsetPoints(pathPoints, normals, -radius);
 
-  return { leftPath, rightPath, referenceDiameter: diameter, referenceRadius: radius };
+  return { id, leftPath, rightPath, referenceDiameter: diameter, referenceRadius: radius };
 };
 
 export const prepareCasingRenderObject = (exaggerationFactor: number, casing: Casing, pathPoints: [number, number][]): CasingRenderObject => {
   const exaggeratedDiameter = casing.diameter * exaggerationFactor;
   const exaggeratedInnerDiameter = casing.innerDiameter * exaggerationFactor;
   const exaggeratedInnerRadius = exaggeratedInnerDiameter / 2;
-  const renderObject = createTubularRenderingObject(exaggeratedDiameter, pathPoints);
+  const renderObject = createTubularRenderingObject(casing.id, exaggeratedDiameter, pathPoints);
 
   const casingWallWidth = renderObject.referenceRadius - exaggeratedInnerRadius;
 
@@ -495,7 +529,6 @@ export const prepareCasingRenderObject = (exaggerationFactor: number, casing: Ca
     kind: 'casing',
     pathPoints,
     polygon,
-    casingId: casing.casingId,
     casingWallWidth,
     hasShoe: casing.hasShoe,
     bottom: casing.end,
@@ -514,9 +547,9 @@ export const createComplexRopeSegmentsForPerforation = (
     throw new Error('Invalid perforation data, perforation is missing attached casing');
   }
 
-  const { outerCasings, overlappingHoles } = findIntersectingItems(perforation.top, perforation.bottom, attachedCasings, casings, holes);
+  const { overlappingOuterStrings, overlappingHoles } = findIntersectingItems(perforation.start, perforation.end, casings, holes);
 
-  const outerDiameterIntervals = [...outerCasings, ...overlappingHoles].map((d) => ({
+  const outerDiameterIntervals = [...overlappingOuterStrings, ...overlappingHoles].map((d) => ({
     start: d.start,
     end: d.end,
   }));
@@ -530,7 +563,7 @@ export const createComplexRopeSegmentsForPerforation = (
 
     const nextDepth = list[index - 1];
 
-    const diameter = findCementOuterDiameterAtDepth(attachedCasings, outerCasings, overlappingHoles, depth) * exaggerationFactor;
+    const diameter = findCementOuterDiameterAtDepth(attachedCasings, overlappingOuterStrings, overlappingHoles, depth) * exaggerationFactor;
 
     return [{ top: nextDepth, bottom: depth, diameter }];
   });

--- a/src/layers/CustomDisplayObjects/ComplexRopeGeometry.ts
+++ b/src/layers/CustomDisplayObjects/ComplexRopeGeometry.ts
@@ -10,7 +10,7 @@ export class ComplexRopeGeometry extends MeshGeometry {
   private segments: ComplexRopeSegment[];
 
   /** Rope texture scale. */
-  private readonly textureScale: number;
+  private readonly textureScale: number; // TODO unused?
 
   /**
    * @param segments - An array of segments with points and diameter to construct this rope.

--- a/src/layers/SchematicLayer.ts
+++ b/src/layers/SchematicLayer.ts
@@ -469,9 +469,6 @@ export class SchematicLayer<T extends SchematicData> extends PixiLayer<T> {
   }
 
   private prepareSymbolRenderObject = (component: CompletionSymbol | PAndASymbol): SymbolRenderObject => {
-    if (component == null) {
-      return;
-    }
     const { exaggerationFactor } = this.options as SchematicLayerOptions<T>;
 
     const exaggeratedDiameter = component.diameter * exaggerationFactor;

--- a/src/layers/schematicInterfaces.ts
+++ b/src/layers/schematicInterfaces.ts
@@ -16,7 +16,6 @@ export interface HoleSize {
 export interface Casing {
   kind: 'casing';
   id: string;
-  casingId: string;
   diameter: number;
   start: number;
   end: number;
@@ -41,9 +40,12 @@ export const isPAndASymbol = (item: PAndA): item is PAndASymbol => item.kind ===
 export interface CementSqueeze {
   kind: 'cementSqueeze';
   id: string;
-  top: number;
-  bottom: number;
-  casingIds?: string[];
+  start: number;
+  end: number;
+  /**
+   * Referenced Casing and Completion ids
+   */
+  referenceIds: string[];
 }
 
 export const isCementSqueeze = (item: PAndA): item is CementSqueeze => item.kind === 'cementSqueeze';
@@ -51,11 +53,12 @@ export const isCementSqueeze = (item: PAndA): item is CementSqueeze => item.kind
 export interface CementPlug {
   kind: 'cementPlug';
   id: string;
-  top: number;
-  bottom: number;
-  holeId?: string;
-  casingId?: string;
-  secondCasingId?: string;
+  start: number;
+  end: number;
+  /**
+   * Referenced Hole, Casing, Completion ids
+   */
+  referenceIds: string[];
 }
 
 export const isCementPlug = (item: PAndA): item is CementSqueeze => item.kind === 'cementPlug';
@@ -101,7 +104,10 @@ export const foldCompletion =
 export interface Cement {
   kind: 'cement';
   id: string;
-  casingIds?: string[];
+  /**
+   *  Referenced Casing and Completion ids
+   */
+  referenceIds: string[];
   toc: number;
 }
 
@@ -120,8 +126,8 @@ export interface Perforation {
   kind: 'perforation';
   subKind: PerforationSubKind;
   id: string;
-  top: number;
-  bottom: number;
+  start: number;
+  end: number;
   /**
    * is the perforation open or sealed?
    */
@@ -254,7 +260,7 @@ export function isOpenHoleFracPack(perf: Perforation) {
 }
 
 export const intersect = (a: Perforation, b: Perforation): boolean => {
-  return a.top < b.bottom && a.bottom > b.top;
+  return a.start < b.end && a.end > b.start;
 };
 
 export interface SchematicData {
@@ -278,12 +284,12 @@ export interface InternalLayerOptions {
   perforationLayerId: string;
 }
 
-export const defaultInternalLayerOptions = (layerId: string) => ({
+export const defaultInternalLayerOptions = (layerId: string): InternalLayerOptions => ({
   holeLayerId: `${layerId}-hole`,
   casingLayerId: `${layerId}-casing`,
   completionLayerId: `${layerId}-completion`,
-  pAndALayerId: `${layerId}-pAndA`,
   cementLayerId: `${layerId}-cement`,
+  pAndALayerId: `${layerId}-pAndA`,
   perforationLayerId: `${layerId}-perforation`,
 });
 
@@ -336,7 +342,7 @@ export const defaultPerforationOptions: PerforationOptions = {
   scalingFactor: 4,
 };
 
-export const defaultCasingOptions = {
+export const defaultCasingOptions: CasingOptions = {
   solidColor: '#dcdcdc',
   lineColor: '#575757',
   shoeSize: {
@@ -351,7 +357,7 @@ export interface CementOptions {
   scalingFactor: number;
 }
 
-export const defaultCementOptions = {
+export const defaultCementOptions: CementOptions = {
   firstColor: '#c7b9ab',
   secondColor: '#5b5b5b',
   scalingFactor: 4,
@@ -363,9 +369,9 @@ export interface CementSqueezeOptions {
   scalingFactor: number;
 }
 
-export const defaultCementSqueezeOptions = {
-  firstColor: '#8b4513',
-  secondColor: '#8b6713',
+export const defaultCementSqueezeOptions: CementSqueezeOptions = {
+  firstColor: '#8b6713',
+  secondColor: '#000000',
   scalingFactor: 4,
 };
 
@@ -374,7 +380,7 @@ export interface ScreenOptions {
   lineColor: string;
 }
 
-export const defaultScreenOptions = {
+export const defaultScreenOptions: ScreenOptions = {
   scalingFactor: 4,
   lineColor: '#63666a',
 };
@@ -385,7 +391,7 @@ export interface TubingOptions {
   scalingFactor: number;
 }
 
-export const defaultTubingOptions = {
+export const defaultTubingOptions: TubingOptions = {
   scalingFactor: 1,
   innerColor: '#eeeeff',
   outerColor: '#777788',
@@ -397,8 +403,8 @@ export interface CementPlugOptions {
   scalingFactor: number;
 }
 
-export const defaultCementPlugOptions = {
+export const defaultCementPlugOptions: CementPlugOptions = {
   firstColor: '#c7b9ab',
-  secondColor: '#c7b9ab',
+  secondColor: '#000000',
   scalingFactor: 4,
 };

--- a/src/layers/schematicInterfaces.ts
+++ b/src/layers/schematicInterfaces.ts
@@ -55,7 +55,7 @@ export interface CementPlug {
   start: number;
   end: number;
   /**
-   * Referenced Hole, Casing, Completion ids
+   * Referenced Casing, Completion ids
    */
   referenceIds: string[];
 }
@@ -132,7 +132,7 @@ export interface Perforation {
    */
   isOpen: boolean;
   /**
-   * currently only looking at 'casingids' and not holeIds.
+   * Referenced Casing ids
    */
   referenceIds: string[];
 }

--- a/src/layers/schematicInterfaces.ts
+++ b/src/layers/schematicInterfaces.ts
@@ -10,7 +10,6 @@ export interface HoleSize {
   diameter: number;
   start: number;
   end: number;
-  innerDiameter?: number;
 }
 
 export interface Casing {

--- a/test/schematicShapeGenerator.test.ts
+++ b/test/schematicShapeGenerator.test.ts
@@ -67,7 +67,7 @@ describe('getUniqueDiameterChangeDepths', () => {
     expect(SchematicShapeGenerator.getUniqueDiameterChangeDepths(intervals, diameterIntervals)).toStrictEqual(expected);
   });
 
-  it('should return start/end interval if diameter intervals is outside', () => {
+  it('should return start/end interval if diameter intervals is out of range', () => {
     const intervals: [number, number] = [100, 200];
     const diameterIntervals = [
       { start: 50, end: 70 },
@@ -135,5 +135,55 @@ describe('findCementPlugInnerDiameterAtDepth', () => {
     const holes = [TestHelpers.createHole(100, 2000)];
 
     expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(100);
+  });
+});
+
+describe('findCementOuterDiameterAtDepth', () => {
+  it('should return extreme diameter if nothing exists at referenced depth', () => {
+    const depth = 1000;
+
+    expect(SchematicShapeGenerator.findCementOuterDiameterAtDepth([], [], [], depth)).toBe(100);
+  });
+
+  it('should prefer holeSize diameter over extreme diameter for given depth', () => {
+    const depth = 1000;
+    const holes: HoleSize[] = [TestHelpers.createHole(100, 2000, 30)];
+
+    expect(SchematicShapeGenerator.findCementOuterDiameterAtDepth([], [], holes, depth)).toBe(30);
+  });
+
+  it('should prefer smallest string outer diameter for given depth, if nothing is attached', () => {
+    const depth = 1000;
+    const nonAttached: (Casing | Completion)[] = [
+      TestHelpers.createCasing(100, 1500, { innerDiameter: 8, outerDiameter: 9 }),
+      TestHelpers.createCasing(100, 1500, { innerDiameter: 13, outerDiameter: 14 }),
+    ];
+    const holes: HoleSize[] = [TestHelpers.createHole(100, 2000, 30)];
+
+    expect(SchematicShapeGenerator.findCementOuterDiameterAtDepth([], nonAttached, holes, depth)).toBe(8);
+  });
+
+  it('should prefer outer string diameter for given depth greater than attached', () => {
+    const depth = 1000;
+    const attached: (Casing | Completion)[] = [TestHelpers.createCasing(100, 1500, { innerDiameter: 10, outerDiameter: 11 })];
+    const nonAttached: (Casing | Completion)[] = [
+      TestHelpers.createCasing(100, 1500, { innerDiameter: 8, outerDiameter: 9 }),
+      TestHelpers.createCasing(100, 1500, { innerDiameter: 13, outerDiameter: 14 }),
+    ];
+    const holes: HoleSize[] = [TestHelpers.createHole(100, 2000, 30)];
+
+    expect(SchematicShapeGenerator.findCementOuterDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(13);
+  });
+
+  it('should prefer extreme diameter for given depth out of range', () => {
+    const depth = 9000;
+    const attached: (Casing | Completion)[] = [TestHelpers.createCasing(100, 1500, { innerDiameter: 10, outerDiameter: 11 })];
+    const nonAttached: (Casing | Completion)[] = [
+      TestHelpers.createCasing(100, 1500, { innerDiameter: 8, outerDiameter: 9 }),
+      TestHelpers.createCasing(100, 1500, { innerDiameter: 13, outerDiameter: 14 }),
+    ];
+    const holes: HoleSize[] = [TestHelpers.createHole(100, 2000, 30)];
+
+    expect(SchematicShapeGenerator.findCementOuterDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(100);
   });
 });

--- a/test/schematicShapeGenerator.test.ts
+++ b/test/schematicShapeGenerator.test.ts
@@ -1,4 +1,7 @@
-import { overlaps } from '../src/datautils/schematicShapeGenerator';
+/* eslint-disable no-magic-numbers */
+import { Casing, Completion, HoleSize } from '../src';
+import * as SchematicShapeGenerator from '../src/datautils/schematicShapeGenerator';
+import * as TestHelpers from './test-helpers';
 
 describe('SVG', () => {
   it('object above/below each other should not overlap', () => {
@@ -10,8 +13,8 @@ describe('SVG', () => {
       top: 21,
       bottom: 30,
     };
-    const test = overlaps(above.top, above.bottom, below.top, below.bottom);
-    const test2 = overlaps(below.top, below.bottom, above.top, above.bottom);
+    const test = SchematicShapeGenerator.overlaps(above.top, above.bottom, below.top, below.bottom);
+    const test2 = SchematicShapeGenerator.overlaps(below.top, below.bottom, above.top, above.bottom);
     expect(test).toBe(false);
     expect(test2).toBe(false);
   });
@@ -25,8 +28,8 @@ describe('SVG', () => {
       top: 15,
       bottom: 25,
     };
-    const test = overlaps(below.top, below.bottom, above.top, above.bottom);
-    const test2 = overlaps(above.top, above.bottom, below.top, below.bottom);
+    const test = SchematicShapeGenerator.overlaps(below.top, below.bottom, above.top, above.bottom);
+    const test2 = SchematicShapeGenerator.overlaps(above.top, above.bottom, below.top, below.bottom);
     expect(test).toBe(true);
     expect(test2).toBe(true);
   });
@@ -40,9 +43,97 @@ describe('SVG', () => {
       top: 10,
       bottom: 40,
     };
-    const test = overlaps(ouside.top, ouside.bottom, inside.top, inside.bottom);
-    const test2 = overlaps(inside.top, inside.bottom, ouside.top, ouside.bottom);
+    const test = SchematicShapeGenerator.overlaps(ouside.top, ouside.bottom, inside.top, inside.bottom);
+    const test2 = SchematicShapeGenerator.overlaps(inside.top, inside.bottom, ouside.top, ouside.bottom);
     expect(test).toBe(true);
     expect(test2).toBe(true);
+  });
+});
+
+describe('getUniqueDiameterChangeDepths', () => {
+  it('should only return change depths within start/end interval', () => {
+    const intervals: [number, number] = [100, 200];
+    const diameterIntervals = [
+      { start: 50, end: 70 },
+      { start: 60, end: 90 },
+      { start: 90, end: 110 },
+      { start: 110, end: 190 },
+      { start: 190, end: 210 },
+      { start: 210, end: 220 },
+    ];
+
+    const expected = [100, 109.9999, 110, 110.0001, 189.9999, 190, 190.0001, 200];
+
+    expect(SchematicShapeGenerator.getUniqueDiameterChangeDepths(intervals, diameterIntervals)).toStrictEqual(expected);
+  });
+
+  it('should return start/end interval if diameter intervals is outside', () => {
+    const intervals: [number, number] = [100, 200];
+    const diameterIntervals = [
+      { start: 50, end: 70 },
+      { start: 60, end: 90 },
+      { start: 210, end: 220 },
+    ];
+
+    const expected = [100, 200];
+
+    expect(SchematicShapeGenerator.getUniqueDiameterChangeDepths(intervals, diameterIntervals)).toStrictEqual(expected);
+  });
+});
+
+describe('findCementPlugInnerDiameterAtDepth', () => {
+  it('should return extreme diameter if nothing exists at referenced depth', () => {
+    const depth = 1000;
+
+    expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth([], [], [], depth)).toBe(100);
+  });
+
+  it('should prefer holeSize diameter over extreme diameter for given depth', () => {
+    const depth = 1000;
+    const attached: (Casing | Completion)[] = [];
+    const nonAttached: (Casing | Completion)[] = [];
+    const holes: HoleSize[] = [TestHelpers.createHole(100, 2000, 30)];
+
+    expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(30);
+  });
+
+  it('should prefer holeSize diameter over extreme diameter for given depth', () => {
+    const depth = 1000;
+    const attached: (Casing | Completion)[] = [];
+    const nonAttached: (Casing | Completion)[] = [];
+    const holes: HoleSize[] = [TestHelpers.createHole(100, 2000, 30)];
+
+    expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(30);
+  });
+
+  it('should prefer minimal non-attached string diameter over hole at depth', () => {
+    const depth = 1000;
+    const attached: (Casing | Completion)[] = [];
+    const nonAttached: (Casing | Completion)[] = [
+      TestHelpers.createTubing(500, 1500, 7),
+      TestHelpers.createCasing(50, 1900, { innerDiameter: 10, outerDiameter: 12 }),
+    ];
+    const holes: HoleSize[] = [TestHelpers.createHole(100, 2000)];
+
+    expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(7);
+  });
+
+  it('should flow to equal or greater diameter outside attached range', () => {
+    const depth = 1100;
+    const attached = [TestHelpers.createCasing(500, 1000, { innerDiameter: 7, outerDiameter: 8 })];
+    const nonAttached = [TestHelpers.createTubing(1000, 1500, 5), TestHelpers.createCasing(500, 1500, { innerDiameter: 10, outerDiameter: 11 })];
+    const holes = [TestHelpers.createHole(100, 2000)];
+
+    expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth(attached, nonAttached, holes, depth)).not.toBe(5); // Tubing
+    expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(10); // casing
+  });
+
+  it('should flow to extreme diameter if depth is out of range', () => {
+    const depth = 9000;
+    const attached = [TestHelpers.createCasing(500, 1000, { innerDiameter: 7, outerDiameter: 8 })];
+    const nonAttached = [TestHelpers.createTubing(1000, 1500, 5), TestHelpers.createCasing(500, 1500, { innerDiameter: 10, outerDiameter: 11 })];
+    const holes = [TestHelpers.createHole(100, 2000)];
+
+    expect(SchematicShapeGenerator.findCementPlugInnerDiameterAtDepth(attached, nonAttached, holes, depth)).toBe(100);
   });
 });

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,6 +1,7 @@
+/* eslint-disable no-magic-numbers */
 import { scaleLinear } from 'd3-scale';
 import { zoomIdentity } from 'd3-zoom';
-import { OnRescaleEvent } from '../src';
+import { Casing, CementPlug, HoleSize, OnRescaleEvent, Tubing } from '../src';
 
 export function rescaleEventStub(): OnRescaleEvent {
   const xBounds = [0, 1000] as [number, number];
@@ -21,3 +22,44 @@ export function rescaleEventStub(): OnRescaleEvent {
 
   return event;
 }
+
+export const generateId = (prefix: string) => `${prefix}-${Math.round(Math.random() * 10000)}`;
+
+export const createCementPlug = (start: number, end: number, referenceIds?: string[]): CementPlug => ({
+  kind: 'cementPlug',
+  id: generateId('cementPlug'),
+  start,
+  end,
+  referenceIds: referenceIds ?? [],
+});
+
+export const createCasing = (
+  start: number,
+  end: number,
+  diameters?: { innerDiameter: number; outerDiameter: number },
+  hasShoe?: boolean,
+): Casing => ({
+  kind: 'casing',
+  id: generateId('casing'),
+  innerDiameter: diameters?.innerDiameter ?? 6,
+  diameter: diameters?.outerDiameter ?? 7,
+  start,
+  end,
+  hasShoe: hasShoe ?? false,
+});
+
+export const createHole = (start: number, end: number, diameter?: number): HoleSize => ({
+  kind: 'hole',
+  id: generateId('holeSize'),
+  diameter: diameter ?? 30,
+  start,
+  end,
+});
+
+export const createTubing = (start: number, end: number, diameter?: number): Tubing => ({
+  kind: 'tubing',
+  id: generateId('holeSize'),
+  diameter: diameter ?? 7,
+  start,
+  end,
+});


### PR DESCRIPTION
-Remove `casingId` from casings. Items referencing that id should rather use the `id` of the casing instead.
-Rename `casingIds` to `referenceIds` for cement related items, as tubing/screen can be cemented in some cases.

Related data is merged from: https://github.com/equinor/esv-intersection-data/pull/11

Refactoring related to PAndA items:
https://github.com/equinor/esv-intersection/issues/461
https://github.com/equinor/esv-intersection/issues/459
https://github.com/equinor/esv-intersection/issues/482