### PR TITLE
chore: upgrade pixi.js to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "jest-environment-jsdom": "^29.3.1",
         "mock-raf": "^1.0.1",
         "pixi-dashed-line": "^1.4.2",
-        "pixi.js": "^6.5.8",
+        "pixi.js": "^7.0.5",
         "prettier": "^2.8.1",
         "rimraf": "^3.0.2",
         "storybook": "^7.0.0-beta.15",
@@ -54,7 +54,7 @@
       },
       "peerDependencies": {
         "pixi-dashed-line": "^1.4.2",
-        "pixi.js": "^6.5.8"
+        "pixi.js": "^7.0.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3881,14 +3881,247 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@pixi/polyfill": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.8.tgz",
-      "integrity": "sha512-z2klHelxTZExMyO4oiLdxJMGzzXnToEIDn7Dwfy3FY+98LbxSa2dVFCgzDsYeiiS8fSMsni2Ru7aZT/DFsRDcA==",
+    "node_modules/@pixi/accessibility": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.0.5.tgz",
+      "integrity": "sha512-+Wiwu7Vj19wa0CrtXlzmswtwNUGsjDCjtmI3HbKHQ3MphjHUKmgx3ga7NL1O53Mwr9XGhkHCOrZzW04fGCtXoA==",
+      "dev": true
+    },
+    "node_modules/@pixi/app": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.0.5.tgz",
+      "integrity": "sha512-fLOJKywqwb4l9mJOE1tgfAhGxqhwb9/UlntivyXQXI6hTYDUivpzIWrWoV+mE09yAvwaw8PR1gnhPuagjrjDuQ==",
+      "dev": true
+    },
+    "node_modules/@pixi/assets": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.0.5.tgz",
+      "integrity": "sha512-GGFrFIAQRzSmmC9ZALSIwaGZNi10Rt0MbuedK+oGPKtSuvQJ37bNGL4sU7PXsTulBdBMUQgbIzmq6FBPnpV9kA==",
       "dev": true,
       "dependencies": {
-        "object-assign": "^4.1.1",
-        "promise-polyfill": "^8.2.0"
+        "@types/css-font-loading-module": "^0.0.7"
+      }
+    },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.0.5.tgz",
+      "integrity": "sha512-OWEtcaPurtpYJLLzDZHq6wDI67ajPb4xl/t+O29Q3PrFSEmZXFfw5lMsDgh9MY4d62jpZwx2dH4QEBK1qjOBvQ==",
+      "dev": true
+    },
+    "node_modules/@pixi/constants": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.0.5.tgz",
+      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg==",
+      "dev": true
+    },
+    "node_modules/@pixi/core": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.0.5.tgz",
+      "integrity": "sha512-+7SgV45t7lw7r8XhtYMv+p0ehc7UPHv9qlMem7Cb/2cZqwxa9Z7TUzQlI9ENb/OsEqURSQ0PJ5ANgEOqQiciiA==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/constants": "7.0.5",
+        "@pixi/extensions": "7.0.5",
+        "@pixi/math": "7.0.5",
+        "@pixi/runner": "7.0.5",
+        "@pixi/settings": "7.0.5",
+        "@pixi/ticker": "7.0.5",
+        "@pixi/utils": "7.0.5",
+        "@types/offscreencanvas": "^2019.6.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/@pixi/display": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.0.5.tgz",
+      "integrity": "sha512-9sXXn7HMFJo5cb4KU3Bdzzhhler9KBuPotHG57gew1MbsMCP32+lvPzqMB1bj6OU0QLjknJxvON77j13CNBh+w==",
+      "dev": true
+    },
+    "node_modules/@pixi/events": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.0.5.tgz",
+      "integrity": "sha512-WKXSOvyfIl2RF5vFG3sT50gvBhH9SqiO4ymdX3GdRi2R+jB5Xo/vJBaBdZCC9sPqC5avhqj6oorQpcL3YoyJkg==",
+      "dev": true
+    },
+    "node_modules/@pixi/extensions": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.0.5.tgz",
+      "integrity": "sha512-zCfhMPPZC5dhH0V/GDK1rUEVAT7Ju9K5bIfbd78hbqUZeK7eq8xA8TFEtPE2rdQJesvdDx+qLDv8QhywyR3Y8Q==",
+      "dev": true
+    },
+    "node_modules/@pixi/extract": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.0.5.tgz",
+      "integrity": "sha512-HMWTTpl/0IGGCWckpAQnXK+kcoLth2WApL3o9l21MeESbKWwbXk4HdiSM42naY651KWGkkdfP+EjLjXmGmlw5A==",
+      "dev": true
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.0.5.tgz",
+      "integrity": "sha512-c2ixjkApAXts0oPI//YP3i2OboxvGekGZHhKmDPuHflI2UoRM1Uy8LXMSNe7xOkSXEa/AkC28d9JQBb+6GZ5Fg==",
+      "dev": true
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.0.5.tgz",
+      "integrity": "sha512-YxncNFYZ/cVRmKVCn1giBiaFaBsYOW+nunx05RV4LJmX9tAxlRFPJLK8Rc1Cqnq5Rk3ZBW4PtXl2gtUIf12haA==",
+      "dev": true
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.0.5.tgz",
+      "integrity": "sha512-sQX0PSsS6o3MgU/Oxr+S9zPMBk+Dxr9H5zgUVSkVcdZh++WQ1LYCPEBwKQFaSDkQ2M8Dxl/lzJgtA5bqpk6MCw==",
+      "dev": true
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.0.5.tgz",
+      "integrity": "sha512-5+34agfCpk+wT+uhrp0JK8/9EW/9llGaYl5IdJ1CsqOHdIQjFbhhqmzEs7U6pYeFbHjQ0ABclMsVZ4qc/rMoRw==",
+      "dev": true
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.0.5.tgz",
+      "integrity": "sha512-o84VCjAvPxGoP+4KehiVQn7v2sJGBvOX+Qxa48v+e/HdRQeuJ31At8XswW5oBAY/7tdM+fJWtNyVJTf2m6HsCQ==",
+      "dev": true
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.0.5.tgz",
+      "integrity": "sha512-OSwd4jCihDlYCPGCv9pogVeehIYS1WbTxsFeWhMIZBc2sffEJeW3QzKKYzMO9c7sy6IljLEqZV7T3sYrmzA1WA==",
+      "dev": true
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.0.5.tgz",
+      "integrity": "sha512-I5Y6IpntiEoJB0HOZ7nSw8r3ZHMyyeE8RMCc3Aud6j5B6CtBkpqCHyxOFNmDod2Ymznj/hWBhLl4ee8SJjRdWg==",
+      "dev": true
+    },
+    "node_modules/@pixi/math": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.0.5.tgz",
+      "integrity": "sha512-v8OCcAL8oK8pf2jtsfHJebTdQ3IA5NI/mdv+Err3F3u4hJHSkDeag9woIBZNfim5ATV/1qriv4b1TT9J+uiL3A==",
+      "dev": true
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.0.5.tgz",
+      "integrity": "sha512-PinHnPbxqou4G4WvwGmmwQAilGHTQd3vC6RlHIOBsxCK/9lw1cQ1Js9VAr0/3cy2Wf5or/AtKTwl0okzBf+4og==",
+      "dev": true
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.0.5.tgz",
+      "integrity": "sha512-+GW5XmavenmSPwZCJDxnXXrflshv0bQGa1gdD2s/T5RxVEP+GYBqPeW2L9fYPowr7070fzzuSVxmcU1yXpv3lw==",
+      "dev": true
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.0.5.tgz",
+      "integrity": "sha512-XlSga7zNDWEzKkOJcifAlXg+FU97pnY9RWm6Gd9zFGY9AQCKWgE++if2/wXMk57pvcTPu3E+li6D3nRYihbVfg==",
+      "dev": true
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.0.5.tgz",
+      "integrity": "sha512-1uVSwlGHGubcaxbzdzWipHvz7DygHWgvxSTpQzSEs8+61EmcuwZHaDj/ceXC7Sir8iP4hp12ScWjii0grMHMfw==",
+      "dev": true
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.0.5.tgz",
+      "integrity": "sha512-Bnq7tZiViireQeLf+8hcuGNK8DuDZTt5AiEISIptqzy0wMOwoLXeBx7+qLwP8RPvImrGhifDotHxDRNB66psDw==",
+      "dev": true
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.0.5.tgz",
+      "integrity": "sha512-1BIRunfi2kUe6fvrFWcYGlbEnqOCeK5hUza2aYyNZz/dSB8T6Zfs0SsBjIy5AfyZpyH8U6KJ4tP5qHp93xDlEw==",
+      "dev": true
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.0.5.tgz",
+      "integrity": "sha512-SdBj5RgXzzJZoIHFopdf5qUbEcNuJSSOOxU0K0WEcaZJH0MPSO5jaUbSKeF/p5C1WfRl2iRc/DzSfBaFBmA9vw==",
+      "dev": true
+    },
+    "node_modules/@pixi/runner": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.0.5.tgz",
+      "integrity": "sha512-7Ym6FXwAv+5pM4oPCk4HNiSG7C69W69zZAuoRaz1hvFpu5fi6J4alhDBI1g3u5S+wyQb6ITuwUpNpDLduBuI5w==",
+      "dev": true
+    },
+    "node_modules/@pixi/settings": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.0.5.tgz",
+      "integrity": "sha512-79cP7z4v47gCKecEU24dXL83hYZoXcv7xBG+sF0RQhsRyHoU2niCXukorgsKeMn0Gq/kA+UtWdV0tSCns9xjQQ==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/constants": "7.0.5",
+        "@types/css-font-loading-module": "^0.0.7"
+      }
+    },
+    "node_modules/@pixi/sprite": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.0.5.tgz",
+      "integrity": "sha512-cWcxz/aB76ZiasQyMa2nugHZn8PmMEk0kmYpdjLCzH+jPf1dpx7YuGuxqR73SbaNuv3sU7Z9BIGZZ7RWr4mpWQ==",
+      "dev": true
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.0.5.tgz",
+      "integrity": "sha512-pV+3w3PXnrhvgAAle21ZsR+6o5A9Di1A/TrnrVqCCM2442rexjhwOUr+pHiXiogq1GjJaVFh2ULPzbuM2Ja9/Q==",
+      "dev": true
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.0.5.tgz",
+      "integrity": "sha512-xpZhk8X5OfX40EYdyCUnX8kmwT7OLx0qXFanN6zvEngHC7Rjgc49Avi9urdCRpmr8USARTFjyxPXtAg5AnsUmQ==",
+      "dev": true
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.0.5.tgz",
+      "integrity": "sha512-Wbvr73mKAB0X6fxPsQs3HduAtk5tTkBAvtAs5+NsSfkPLWjMU8HGpcEx/mr7rrGraw9DxGzZ4bwdeZuGjAWFyA==",
+      "dev": true
+    },
+    "node_modules/@pixi/text": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.0.5.tgz",
+      "integrity": "sha512-B/yUUqUeqx/X0H3I33xalttBJ3KlkADJioDI+K3WW1D6ue6qENnWby/JKd/8ZiqRdQfyZ9jsmsldfR2OEzLIJA==",
+      "dev": true
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.0.5.tgz",
+      "integrity": "sha512-Ee4apuf8riXQw5j97IyzElS5Vu9Dnk0TvXZQsqzZeZHbmwL5KVjrF4dnRQIL8FGFl1nrq/OpL0HWI83IxqwC6Q==",
+      "dev": true
+    },
+    "node_modules/@pixi/ticker": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.0.5.tgz",
+      "integrity": "sha512-a/QIvInjKTK5HngkRXjA9EYEuDKkOwEQ4bAZZYx7bjJzFseWULkNsSAdnfqjny+BOLIKhF7u2Hf4n+ef1H2xMg==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/extensions": "7.0.5",
+        "@pixi/settings": "7.0.5"
+      }
+    },
+    "node_modules/@pixi/utils": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.0.5.tgz",
+      "integrity": "sha512-aFweyXTC2dlsyVQNQarsPQXIuuQDIPSV5WI4unU3VpQ+SaKmH3LTHm4+75JgOweGwRclUw4c/kEYf92RmQBmHg==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/constants": "7.0.5",
+        "@pixi/settings": "7.0.5",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -7965,6 +8198,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "dev": true
     },
     "node_modules/@types/d3": {
       "version": "7.4.0",
@@ -12352,9 +12591,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "node_modules/exit": {
@@ -20117,457 +20356,44 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.8.tgz",
-      "integrity": "sha512-TAovIMCvKiWlonyAEbStOSq2+GZliRgs+Pqlavffa/D0Rmvmb78bytWRxgonGx1qkg7G8W7eIbF55tFP4a5Krw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.0.5.tgz",
+      "integrity": "sha512-XCFSUojaIdDz745bvQDmyEsJ6A3eh7mCeGW+esukzLQFPnDP/NvPsJszJKhyRuoktyzJb5xsuV08Eh3Y7+VC3w==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "6.5.8",
-        "@pixi/app": "6.5.8",
-        "@pixi/compressed-textures": "6.5.8",
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/extensions": "6.5.8",
-        "@pixi/extract": "6.5.8",
-        "@pixi/filter-alpha": "6.5.8",
-        "@pixi/filter-blur": "6.5.8",
-        "@pixi/filter-color-matrix": "6.5.8",
-        "@pixi/filter-displacement": "6.5.8",
-        "@pixi/filter-fxaa": "6.5.8",
-        "@pixi/filter-noise": "6.5.8",
-        "@pixi/graphics": "6.5.8",
-        "@pixi/interaction": "6.5.8",
-        "@pixi/loaders": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/mesh": "6.5.8",
-        "@pixi/mesh-extras": "6.5.8",
-        "@pixi/mixin-cache-as-bitmap": "6.5.8",
-        "@pixi/mixin-get-child-by-name": "6.5.8",
-        "@pixi/mixin-get-global-position": "6.5.8",
-        "@pixi/particle-container": "6.5.8",
-        "@pixi/polyfill": "6.5.8",
-        "@pixi/prepare": "6.5.8",
-        "@pixi/runner": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/sprite-animated": "6.5.8",
-        "@pixi/sprite-tiling": "6.5.8",
-        "@pixi/spritesheet": "6.5.8",
-        "@pixi/text": "6.5.8",
-        "@pixi/text-bitmap": "6.5.8",
-        "@pixi/ticker": "6.5.8",
-        "@pixi/utils": "6.5.8"
+        "@pixi/accessibility": "7.0.5",
+        "@pixi/app": "7.0.5",
+        "@pixi/assets": "7.0.5",
+        "@pixi/compressed-textures": "7.0.5",
+        "@pixi/core": "7.0.5",
+        "@pixi/display": "7.0.5",
+        "@pixi/events": "7.0.5",
+        "@pixi/extensions": "7.0.5",
+        "@pixi/extract": "7.0.5",
+        "@pixi/filter-alpha": "7.0.5",
+        "@pixi/filter-blur": "7.0.5",
+        "@pixi/filter-color-matrix": "7.0.5",
+        "@pixi/filter-displacement": "7.0.5",
+        "@pixi/filter-fxaa": "7.0.5",
+        "@pixi/filter-noise": "7.0.5",
+        "@pixi/graphics": "7.0.5",
+        "@pixi/mesh": "7.0.5",
+        "@pixi/mesh-extras": "7.0.5",
+        "@pixi/mixin-cache-as-bitmap": "7.0.5",
+        "@pixi/mixin-get-child-by-name": "7.0.5",
+        "@pixi/mixin-get-global-position": "7.0.5",
+        "@pixi/particle-container": "7.0.5",
+        "@pixi/prepare": "7.0.5",
+        "@pixi/sprite": "7.0.5",
+        "@pixi/sprite-animated": "7.0.5",
+        "@pixi/sprite-tiling": "7.0.5",
+        "@pixi/spritesheet": "7.0.5",
+        "@pixi/text": "7.0.5",
+        "@pixi/text-bitmap": "7.0.5"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/accessibility": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.8.tgz",
-      "integrity": "sha512-3q1YaZeZKOoblgbxTQg2L0RAp9jtNtGcl/7kce+XelqxwIMS3p8411nwo90YO53XCqc/eQW2SoZ+hSXqcL0qOw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/app": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.8.tgz",
-      "integrity": "sha512-pDPkamtYDaPhscNxack+bHNqazCwrqw6cAotKyoz1mvLXeGhxqTntOcfgGLZR2fNbnY8EBmdduLvH7n2jI/LTg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/compressed-textures": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.8.tgz",
-      "integrity": "sha512-nW74kcvdEoe4a2U7Ekx4egqdH1tYKC2kCOZxKWYcUARqz26tS0ddwSRyIs05In6EChmXHXGy/MtShdueMH38TA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/loaders": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/constants": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.8.tgz",
-      "integrity": "sha512-yYRCebBPqajm1kn5f8QQTTvl7oDRDk1nppfO+JpqbrFXg0W7oqIMurec3KeG9RdZW5foOiXDoz1Gw+VtolYIEw==",
-      "dev": true
-    },
-    "node_modules/pixi.js/node_modules/@pixi/core": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.8.tgz",
-      "integrity": "sha512-Gconik7/PpFPMpCpOddXVIPx5C2StWKw7lQ4YX19yQ+cRRmecCea2cV0xTBtpEjjx0ilX7nBfIEuZ4zIlMmlbA==",
-      "dev": true,
-      "dependencies": {
-        "@types/offscreencanvas": "^2019.6.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/extensions": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/runner": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/ticker": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/display": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.8.tgz",
-      "integrity": "sha512-2K8YOG8s0iF8x/k2Q0RTFmoMJ9biI6PXEh76nH3EqUFdpyrIIgrG5aOMnCkVDvOxlgVRrKG8Q3JBHlSievTmuw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/extensions": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.8.tgz",
-      "integrity": "sha512-6vEV801Vn/EkU/qjFiZ76OZWPq5KsBR2r+P5gfKv4YLnaDc3A+0IpUOJ7sLBAJqmr0iw68g6xV6MnuqVjNGjFg==",
-      "dev": true
-    },
-    "node_modules/pixi.js/node_modules/@pixi/extract": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.8.tgz",
-      "integrity": "sha512-qbuuD/iBA4J+TCBgrbMe8oDUFbCriyy9LTKEtQp+pghKD5MEMvJ3nO6Osumxqiqta2kYU6WldFLTldKyHEiQ7Q==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-alpha": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.8.tgz",
-      "integrity": "sha512-W4IkFTLTP84H+DS9XIdBGunAEpaXLrasDc4CQBeyp4c4hBlGlzriUZp30vkmqm7GPmFhzPe7aiJtNYgUpxKQBQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-blur": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.8.tgz",
-      "integrity": "sha512-1UOfVthFBnavzTBkR6R+1tWhOOymtWvcpuJILhxf3mryLj9eqYbQubAG0gV8Da6Ibsgk+v73ORnOJyWR3POFvw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/settings": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-color-matrix": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.8.tgz",
-      "integrity": "sha512-iix+a/KEi6HAwZwkUH3nkIzyLu0ln3HBuHEFLUUhug7xrQgQgGrTQZ32iWlfpJD/BZuKphIGfzlxMFfvyQmkVw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-displacement": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.8.tgz",
-      "integrity": "sha512-qLRka5cQbeH6667A+ViYoemsXGGe2tOBt92vM91+slMt9OBGtR0ymlpGU7VxBggWUlu5PE10zYed/xw78uSpig==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/math": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-fxaa": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.8.tgz",
-      "integrity": "sha512-TxsBH2z2RMj0mqr13VPi18/EJ/Kn38J2u65HonJmhbvTaoK9HWMExTvl38Xjg0k7TlepwhoayxMhQ1uCw9xudQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-noise": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.8.tgz",
-      "integrity": "sha512-BZHKuzV5Mdn+EpC52lFYpd6jUcrL+YQHdq0v0yJfVtpW2ripseQxMGxxXr6Yxp2P4F3g2aY2JrfX2VztosmGLA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/graphics": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.8.tgz",
-      "integrity": "sha512-DUuUXHO4t5fg+n+srMkHX38QEH3WtS1IMXtovBGFJkkopG0Z0xjxSp5XvsPPw1J//4fzkHZI5OBrlN613p9+sg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/interaction": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.8.tgz",
-      "integrity": "sha512-uP247r0f47vo9WSpEnsUfeD1izxVGpjtg4iAyGT/02ezWse2vD1aEL8AbxFa65TL0IXOKsHEQudCVL+wjnbSKQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/ticker": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/loaders": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.8.tgz",
-      "integrity": "sha512-mj11UPKsqWaTEPMpCnFugr6heKkQeNFuVSddSwE8crg19l46zcMhk3ucpQX15RDpAdDJjtl3OraevQCHHbNENw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/math": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.8.tgz",
-      "integrity": "sha512-9493KEH5ITnjOZvQZbaU22lD0kcg/XhNh+309KYfwFX787zA1BN/7is06oHEgHBDb2NemqioYi6sw1WnECgQig==",
-      "dev": true
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.8.tgz",
-      "integrity": "sha512-iZZGkh8QBhnfMEgpJsuwemFZZVatodckCgj7N8t1hyHEf0aOWEA6wp5N0Osa3mhltokl7BGnZZLxaR8NtjaiEQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh-extras": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.8.tgz",
-      "integrity": "sha512-eU2I53yZUFxKbTYZvyRfUcdina3WOl87fyqYwAoaHosU9VgbFl16YADKTGV+NflNp6RCTwU/UIPZ1T19W/iysw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/mesh": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.8.tgz",
-      "integrity": "sha512-5TTv4w8v7guI6z3gKz5ppUCbNMRw+8RRNru/aq65qUl6kcUaJiYwQdBFJ/vJwpI9ePEScWrCuLVEc8QtX6xjNw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.8.tgz",
-      "integrity": "sha512-b15HTdHpW4ErDBpf7wm1vvWHrTv5kQzElXrwAPBCnLgvronfSL9mL7npOUkZOybUorCoEBq/7oNVjkimsQc5gw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/display": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-global-position": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.8.tgz",
-      "integrity": "sha512-Y5epEW5mRrgpDOHvfc92t0PaBgboBKXR4n/AzOOFt0h9GRNTmVKYBpUQPp/HO+r1Bxq+XbaGm1CyfkjUUxnORA==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/particle-container": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.8.tgz",
-      "integrity": "sha512-wc4j84PssPWmZLpOJTLLC7MftCULzkQMAfVlwOERhNTZ+6E1LIKw91wDWZe9LQ/20iarzQwQXo0a4uNlJlhnVQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/prepare": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.8.tgz",
-      "integrity": "sha512-anrAcjX3r9ZzK/L6Fw7GhE1pCkjhSfBsxUTlVhuRKJPFC+A3BNpZCwy3GzyvHP4ocl8wvUMzuz5BB5l0AoBCFw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/graphics": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/text": "6.5.8",
-        "@pixi/ticker": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/runner": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.8.tgz",
-      "integrity": "sha512-/9KVgQjTKiBa1qHdNmhP9I+AHgC/Eu9QiKcc+oakLCJtpYi79lx+nDFrpLUamIi2c7lP0hDWVe0XqlQeYmSwag==",
-      "dev": true
-    },
-    "node_modules/pixi.js/node_modules/@pixi/settings": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.8.tgz",
-      "integrity": "sha512-gmnwHkg9+tlQRuFNOdimzl73Dup2fdEo/VYaF7spT+8womE4KWAvARCBMqY/10aAx1iYeYuo5av/RfqrePB5Hg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.8.tgz",
-      "integrity": "sha512-ywvbrNgjK+K93X9cvHtDCnsBtU7B9JD/3wg+1G6v1Ktrr2E1gwVIQK1NANBrjzt6cYGphz5EqGAW68d0rMBliw==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-animated": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.8.tgz",
-      "integrity": "sha512-woPT2cF1BaC0PDWdDrqJ0+DYcyIeXzZLq6bVx2YYia3+jJao1Zjmz1ns5e7YMUTEG7DoVFfhO6CC81YimsMG5w==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/ticker": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-tiling": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.8.tgz",
-      "integrity": "sha512-PG3tiWI6uUest/d7HAz4/3I8NjpYyeMUL2WDy86nMXCJ6bLdTs/s9Nq3DLckaUsyIMTGsVbj/BXjE8LP1WDTog==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/spritesheet": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.8.tgz",
-      "integrity": "sha512-WiJd4fKpSitD3A+/u5q8IPoHXMFT8++bsluhuJvDwzo//s0PHb9qExlF2xos7zUmekmydEFMkDnrl4+lWn2cyg==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/loaders": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.8.tgz",
-      "integrity": "sha512-7AZPj5+vWcUjK0QzQ3ehiEwEqywiWR8NhDmnnN5nRNHR9u5IOOnqCQtBTdDffYPN0uMgCi8MzUPwTJhGuyOeww==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/core": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text-bitmap": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.8.tgz",
-      "integrity": "sha512-6VxejDc0gOu5HFN06m6i94xBZHdZ728iao8q+hEOjavGR5i2Pv3xseuke1qY0iN4q6Z+wTkcmoK5BfEVi2ujdQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/loaders": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/mesh": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/text": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/ticker": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.8.tgz",
-      "integrity": "sha512-7VKq5hfnRDSv6a16pATqZAmpQfEu4G171iUTloy3QZfbnPw0s3JervZSih1yJJD84GXEF4VzYB26pJ/x3arGjQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@pixi/extensions": "6.5.8",
-        "@pixi/settings": "6.5.8"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/utils": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.8.tgz",
-      "integrity": "sha512-zLnvmVQBWPDnwkfvrSpBBF2XpWSMt+kQAsX562eqjuME63ic9M6fK4u/IaA8csdlG2wtcjBvSYWrpWmPq0bWag==",
-      "dev": true,
-      "dependencies": {
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^3.1.0",
-        "url": "^0.11.0"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.5.8",
-        "@pixi/settings": "6.5.8"
       }
     },
     "node_modules/pkg-dir": {
@@ -20700,12 +20526,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promise-polyfill": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
-      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
-      "dev": true
-    },
     "node_modules/prompts": {
       "version": "2.4.0",
       "dev": true,
@@ -20763,6 +20583,12 @@
       "version": "1.9.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "dev": true
     },
     "node_modules/puppeteer-core": {
       "version": "2.1.1",
@@ -20856,6 +20682,9 @@
     },
     "node_modules/querystring": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -23127,8 +22956,9 @@
     },
     "node_modules/url": {
       "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -23142,11 +22972,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -26302,14 +26127,243 @@
         "fastq": "^1.6.0"
       }
     },
-    "@pixi/polyfill": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.8.tgz",
-      "integrity": "sha512-z2klHelxTZExMyO4oiLdxJMGzzXnToEIDn7Dwfy3FY+98LbxSa2dVFCgzDsYeiiS8fSMsni2Ru7aZT/DFsRDcA==",
+    "@pixi/accessibility": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.0.5.tgz",
+      "integrity": "sha512-+Wiwu7Vj19wa0CrtXlzmswtwNUGsjDCjtmI3HbKHQ3MphjHUKmgx3ga7NL1O53Mwr9XGhkHCOrZzW04fGCtXoA==",
+      "dev": true
+    },
+    "@pixi/app": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.0.5.tgz",
+      "integrity": "sha512-fLOJKywqwb4l9mJOE1tgfAhGxqhwb9/UlntivyXQXI6hTYDUivpzIWrWoV+mE09yAvwaw8PR1gnhPuagjrjDuQ==",
+      "dev": true
+    },
+    "@pixi/assets": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.0.5.tgz",
+      "integrity": "sha512-GGFrFIAQRzSmmC9ZALSIwaGZNi10Rt0MbuedK+oGPKtSuvQJ37bNGL4sU7PXsTulBdBMUQgbIzmq6FBPnpV9kA==",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.1",
-        "promise-polyfill": "^8.2.0"
+        "@types/css-font-loading-module": "^0.0.7"
+      }
+    },
+    "@pixi/compressed-textures": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.0.5.tgz",
+      "integrity": "sha512-OWEtcaPurtpYJLLzDZHq6wDI67ajPb4xl/t+O29Q3PrFSEmZXFfw5lMsDgh9MY4d62jpZwx2dH4QEBK1qjOBvQ==",
+      "dev": true
+    },
+    "@pixi/constants": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.0.5.tgz",
+      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg==",
+      "dev": true
+    },
+    "@pixi/core": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.0.5.tgz",
+      "integrity": "sha512-+7SgV45t7lw7r8XhtYMv+p0ehc7UPHv9qlMem7Cb/2cZqwxa9Z7TUzQlI9ENb/OsEqURSQ0PJ5ANgEOqQiciiA==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "7.0.5",
+        "@pixi/extensions": "7.0.5",
+        "@pixi/math": "7.0.5",
+        "@pixi/runner": "7.0.5",
+        "@pixi/settings": "7.0.5",
+        "@pixi/ticker": "7.0.5",
+        "@pixi/utils": "7.0.5",
+        "@types/offscreencanvas": "^2019.6.4"
+      }
+    },
+    "@pixi/display": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.0.5.tgz",
+      "integrity": "sha512-9sXXn7HMFJo5cb4KU3Bdzzhhler9KBuPotHG57gew1MbsMCP32+lvPzqMB1bj6OU0QLjknJxvON77j13CNBh+w==",
+      "dev": true
+    },
+    "@pixi/events": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.0.5.tgz",
+      "integrity": "sha512-WKXSOvyfIl2RF5vFG3sT50gvBhH9SqiO4ymdX3GdRi2R+jB5Xo/vJBaBdZCC9sPqC5avhqj6oorQpcL3YoyJkg==",
+      "dev": true
+    },
+    "@pixi/extensions": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.0.5.tgz",
+      "integrity": "sha512-zCfhMPPZC5dhH0V/GDK1rUEVAT7Ju9K5bIfbd78hbqUZeK7eq8xA8TFEtPE2rdQJesvdDx+qLDv8QhywyR3Y8Q==",
+      "dev": true
+    },
+    "@pixi/extract": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.0.5.tgz",
+      "integrity": "sha512-HMWTTpl/0IGGCWckpAQnXK+kcoLth2WApL3o9l21MeESbKWwbXk4HdiSM42naY651KWGkkdfP+EjLjXmGmlw5A==",
+      "dev": true
+    },
+    "@pixi/filter-alpha": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.0.5.tgz",
+      "integrity": "sha512-c2ixjkApAXts0oPI//YP3i2OboxvGekGZHhKmDPuHflI2UoRM1Uy8LXMSNe7xOkSXEa/AkC28d9JQBb+6GZ5Fg==",
+      "dev": true
+    },
+    "@pixi/filter-blur": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.0.5.tgz",
+      "integrity": "sha512-YxncNFYZ/cVRmKVCn1giBiaFaBsYOW+nunx05RV4LJmX9tAxlRFPJLK8Rc1Cqnq5Rk3ZBW4PtXl2gtUIf12haA==",
+      "dev": true
+    },
+    "@pixi/filter-color-matrix": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.0.5.tgz",
+      "integrity": "sha512-sQX0PSsS6o3MgU/Oxr+S9zPMBk+Dxr9H5zgUVSkVcdZh++WQ1LYCPEBwKQFaSDkQ2M8Dxl/lzJgtA5bqpk6MCw==",
+      "dev": true
+    },
+    "@pixi/filter-displacement": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.0.5.tgz",
+      "integrity": "sha512-5+34agfCpk+wT+uhrp0JK8/9EW/9llGaYl5IdJ1CsqOHdIQjFbhhqmzEs7U6pYeFbHjQ0ABclMsVZ4qc/rMoRw==",
+      "dev": true
+    },
+    "@pixi/filter-fxaa": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.0.5.tgz",
+      "integrity": "sha512-o84VCjAvPxGoP+4KehiVQn7v2sJGBvOX+Qxa48v+e/HdRQeuJ31At8XswW5oBAY/7tdM+fJWtNyVJTf2m6HsCQ==",
+      "dev": true
+    },
+    "@pixi/filter-noise": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.0.5.tgz",
+      "integrity": "sha512-OSwd4jCihDlYCPGCv9pogVeehIYS1WbTxsFeWhMIZBc2sffEJeW3QzKKYzMO9c7sy6IljLEqZV7T3sYrmzA1WA==",
+      "dev": true
+    },
+    "@pixi/graphics": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.0.5.tgz",
+      "integrity": "sha512-I5Y6IpntiEoJB0HOZ7nSw8r3ZHMyyeE8RMCc3Aud6j5B6CtBkpqCHyxOFNmDod2Ymznj/hWBhLl4ee8SJjRdWg==",
+      "dev": true
+    },
+    "@pixi/math": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.0.5.tgz",
+      "integrity": "sha512-v8OCcAL8oK8pf2jtsfHJebTdQ3IA5NI/mdv+Err3F3u4hJHSkDeag9woIBZNfim5ATV/1qriv4b1TT9J+uiL3A==",
+      "dev": true
+    },
+    "@pixi/mesh": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.0.5.tgz",
+      "integrity": "sha512-PinHnPbxqou4G4WvwGmmwQAilGHTQd3vC6RlHIOBsxCK/9lw1cQ1Js9VAr0/3cy2Wf5or/AtKTwl0okzBf+4og==",
+      "dev": true
+    },
+    "@pixi/mesh-extras": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.0.5.tgz",
+      "integrity": "sha512-+GW5XmavenmSPwZCJDxnXXrflshv0bQGa1gdD2s/T5RxVEP+GYBqPeW2L9fYPowr7070fzzuSVxmcU1yXpv3lw==",
+      "dev": true
+    },
+    "@pixi/mixin-cache-as-bitmap": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.0.5.tgz",
+      "integrity": "sha512-XlSga7zNDWEzKkOJcifAlXg+FU97pnY9RWm6Gd9zFGY9AQCKWgE++if2/wXMk57pvcTPu3E+li6D3nRYihbVfg==",
+      "dev": true
+    },
+    "@pixi/mixin-get-child-by-name": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.0.5.tgz",
+      "integrity": "sha512-1uVSwlGHGubcaxbzdzWipHvz7DygHWgvxSTpQzSEs8+61EmcuwZHaDj/ceXC7Sir8iP4hp12ScWjii0grMHMfw==",
+      "dev": true
+    },
+    "@pixi/mixin-get-global-position": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.0.5.tgz",
+      "integrity": "sha512-Bnq7tZiViireQeLf+8hcuGNK8DuDZTt5AiEISIptqzy0wMOwoLXeBx7+qLwP8RPvImrGhifDotHxDRNB66psDw==",
+      "dev": true
+    },
+    "@pixi/particle-container": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.0.5.tgz",
+      "integrity": "sha512-1BIRunfi2kUe6fvrFWcYGlbEnqOCeK5hUza2aYyNZz/dSB8T6Zfs0SsBjIy5AfyZpyH8U6KJ4tP5qHp93xDlEw==",
+      "dev": true
+    },
+    "@pixi/prepare": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.0.5.tgz",
+      "integrity": "sha512-SdBj5RgXzzJZoIHFopdf5qUbEcNuJSSOOxU0K0WEcaZJH0MPSO5jaUbSKeF/p5C1WfRl2iRc/DzSfBaFBmA9vw==",
+      "dev": true
+    },
+    "@pixi/runner": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.0.5.tgz",
+      "integrity": "sha512-7Ym6FXwAv+5pM4oPCk4HNiSG7C69W69zZAuoRaz1hvFpu5fi6J4alhDBI1g3u5S+wyQb6ITuwUpNpDLduBuI5w==",
+      "dev": true
+    },
+    "@pixi/settings": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.0.5.tgz",
+      "integrity": "sha512-79cP7z4v47gCKecEU24dXL83hYZoXcv7xBG+sF0RQhsRyHoU2niCXukorgsKeMn0Gq/kA+UtWdV0tSCns9xjQQ==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "7.0.5",
+        "@types/css-font-loading-module": "^0.0.7"
+      }
+    },
+    "@pixi/sprite": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.0.5.tgz",
+      "integrity": "sha512-cWcxz/aB76ZiasQyMa2nugHZn8PmMEk0kmYpdjLCzH+jPf1dpx7YuGuxqR73SbaNuv3sU7Z9BIGZZ7RWr4mpWQ==",
+      "dev": true
+    },
+    "@pixi/sprite-animated": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.0.5.tgz",
+      "integrity": "sha512-pV+3w3PXnrhvgAAle21ZsR+6o5A9Di1A/TrnrVqCCM2442rexjhwOUr+pHiXiogq1GjJaVFh2ULPzbuM2Ja9/Q==",
+      "dev": true
+    },
+    "@pixi/sprite-tiling": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.0.5.tgz",
+      "integrity": "sha512-xpZhk8X5OfX40EYdyCUnX8kmwT7OLx0qXFanN6zvEngHC7Rjgc49Avi9urdCRpmr8USARTFjyxPXtAg5AnsUmQ==",
+      "dev": true
+    },
+    "@pixi/spritesheet": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.0.5.tgz",
+      "integrity": "sha512-Wbvr73mKAB0X6fxPsQs3HduAtk5tTkBAvtAs5+NsSfkPLWjMU8HGpcEx/mr7rrGraw9DxGzZ4bwdeZuGjAWFyA==",
+      "dev": true
+    },
+    "@pixi/text": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.0.5.tgz",
+      "integrity": "sha512-B/yUUqUeqx/X0H3I33xalttBJ3KlkADJioDI+K3WW1D6ue6qENnWby/JKd/8ZiqRdQfyZ9jsmsldfR2OEzLIJA==",
+      "dev": true
+    },
+    "@pixi/text-bitmap": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.0.5.tgz",
+      "integrity": "sha512-Ee4apuf8riXQw5j97IyzElS5Vu9Dnk0TvXZQsqzZeZHbmwL5KVjrF4dnRQIL8FGFl1nrq/OpL0HWI83IxqwC6Q==",
+      "dev": true
+    },
+    "@pixi/ticker": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.0.5.tgz",
+      "integrity": "sha512-a/QIvInjKTK5HngkRXjA9EYEuDKkOwEQ4bAZZYx7bjJzFseWULkNsSAdnfqjny+BOLIKhF7u2Hf4n+ef1H2xMg==",
+      "dev": true,
+      "requires": {
+        "@pixi/extensions": "7.0.5",
+        "@pixi/settings": "7.0.5"
+      }
+    },
+    "@pixi/utils": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.0.5.tgz",
+      "integrity": "sha512-aFweyXTC2dlsyVQNQarsPQXIuuQDIPSV5WI4unU3VpQ+SaKmH3LTHm4+75JgOweGwRclUw4c/kEYf92RmQBmHg==",
+      "dev": true,
+      "requires": {
+        "@pixi/constants": "7.0.5",
+        "@pixi/settings": "7.0.5",
+        "@types/earcut": "^2.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
+        "url": "^0.11.0"
       }
     },
     "@rollup/pluginutils": {
@@ -29290,6 +29344,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "dev": true
     },
     "@types/d3": {
       "version": "7.4.0",
@@ -32308,9 +32368,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "exit": {
@@ -37910,297 +37970,40 @@
       "requires": {}
     },
     "pixi.js": {
-      "version": "6.5.8",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.8.tgz",
-      "integrity": "sha512-TAovIMCvKiWlonyAEbStOSq2+GZliRgs+Pqlavffa/D0Rmvmb78bytWRxgonGx1qkg7G8W7eIbF55tFP4a5Krw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.0.5.tgz",
+      "integrity": "sha512-XCFSUojaIdDz745bvQDmyEsJ6A3eh7mCeGW+esukzLQFPnDP/NvPsJszJKhyRuoktyzJb5xsuV08Eh3Y7+VC3w==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "6.5.8",
-        "@pixi/app": "6.5.8",
-        "@pixi/compressed-textures": "6.5.8",
-        "@pixi/constants": "6.5.8",
-        "@pixi/core": "6.5.8",
-        "@pixi/display": "6.5.8",
-        "@pixi/extensions": "6.5.8",
-        "@pixi/extract": "6.5.8",
-        "@pixi/filter-alpha": "6.5.8",
-        "@pixi/filter-blur": "6.5.8",
-        "@pixi/filter-color-matrix": "6.5.8",
-        "@pixi/filter-displacement": "6.5.8",
-        "@pixi/filter-fxaa": "6.5.8",
-        "@pixi/filter-noise": "6.5.8",
-        "@pixi/graphics": "6.5.8",
-        "@pixi/interaction": "6.5.8",
-        "@pixi/loaders": "6.5.8",
-        "@pixi/math": "6.5.8",
-        "@pixi/mesh": "6.5.8",
-        "@pixi/mesh-extras": "6.5.8",
-        "@pixi/mixin-cache-as-bitmap": "6.5.8",
-        "@pixi/mixin-get-child-by-name": "6.5.8",
-        "@pixi/mixin-get-global-position": "6.5.8",
-        "@pixi/particle-container": "6.5.8",
-        "@pixi/polyfill": "6.5.8",
-        "@pixi/prepare": "6.5.8",
-        "@pixi/runner": "6.5.8",
-        "@pixi/settings": "6.5.8",
-        "@pixi/sprite": "6.5.8",
-        "@pixi/sprite-animated": "6.5.8",
-        "@pixi/sprite-tiling": "6.5.8",
-        "@pixi/spritesheet": "6.5.8",
-        "@pixi/text": "6.5.8",
-        "@pixi/text-bitmap": "6.5.8",
-        "@pixi/ticker": "6.5.8",
-        "@pixi/utils": "6.5.8"
-      },
-      "dependencies": {
-        "@pixi/accessibility": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.8.tgz",
-          "integrity": "sha512-3q1YaZeZKOoblgbxTQg2L0RAp9jtNtGcl/7kce+XelqxwIMS3p8411nwo90YO53XCqc/eQW2SoZ+hSXqcL0qOw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/app": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.8.tgz",
-          "integrity": "sha512-pDPkamtYDaPhscNxack+bHNqazCwrqw6cAotKyoz1mvLXeGhxqTntOcfgGLZR2fNbnY8EBmdduLvH7n2jI/LTg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/compressed-textures": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.8.tgz",
-          "integrity": "sha512-nW74kcvdEoe4a2U7Ekx4egqdH1tYKC2kCOZxKWYcUARqz26tS0ddwSRyIs05In6EChmXHXGy/MtShdueMH38TA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/constants": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.8.tgz",
-          "integrity": "sha512-yYRCebBPqajm1kn5f8QQTTvl7oDRDk1nppfO+JpqbrFXg0W7oqIMurec3KeG9RdZW5foOiXDoz1Gw+VtolYIEw==",
-          "dev": true
-        },
-        "@pixi/core": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.8.tgz",
-          "integrity": "sha512-Gconik7/PpFPMpCpOddXVIPx5C2StWKw7lQ4YX19yQ+cRRmecCea2cV0xTBtpEjjx0ilX7nBfIEuZ4zIlMmlbA==",
-          "dev": true,
-          "requires": {
-            "@types/offscreencanvas": "^2019.6.4"
-          }
-        },
-        "@pixi/display": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.8.tgz",
-          "integrity": "sha512-2K8YOG8s0iF8x/k2Q0RTFmoMJ9biI6PXEh76nH3EqUFdpyrIIgrG5aOMnCkVDvOxlgVRrKG8Q3JBHlSievTmuw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/extensions": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.8.tgz",
-          "integrity": "sha512-6vEV801Vn/EkU/qjFiZ76OZWPq5KsBR2r+P5gfKv4YLnaDc3A+0IpUOJ7sLBAJqmr0iw68g6xV6MnuqVjNGjFg==",
-          "dev": true
-        },
-        "@pixi/extract": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.8.tgz",
-          "integrity": "sha512-qbuuD/iBA4J+TCBgrbMe8oDUFbCriyy9LTKEtQp+pghKD5MEMvJ3nO6Osumxqiqta2kYU6WldFLTldKyHEiQ7Q==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-alpha": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.8.tgz",
-          "integrity": "sha512-W4IkFTLTP84H+DS9XIdBGunAEpaXLrasDc4CQBeyp4c4hBlGlzriUZp30vkmqm7GPmFhzPe7aiJtNYgUpxKQBQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-blur": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.8.tgz",
-          "integrity": "sha512-1UOfVthFBnavzTBkR6R+1tWhOOymtWvcpuJILhxf3mryLj9eqYbQubAG0gV8Da6Ibsgk+v73ORnOJyWR3POFvw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-color-matrix": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.8.tgz",
-          "integrity": "sha512-iix+a/KEi6HAwZwkUH3nkIzyLu0ln3HBuHEFLUUhug7xrQgQgGrTQZ32iWlfpJD/BZuKphIGfzlxMFfvyQmkVw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-displacement": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.8.tgz",
-          "integrity": "sha512-qLRka5cQbeH6667A+ViYoemsXGGe2tOBt92vM91+slMt9OBGtR0ymlpGU7VxBggWUlu5PE10zYed/xw78uSpig==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-fxaa": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.8.tgz",
-          "integrity": "sha512-TxsBH2z2RMj0mqr13VPi18/EJ/Kn38J2u65HonJmhbvTaoK9HWMExTvl38Xjg0k7TlepwhoayxMhQ1uCw9xudQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/filter-noise": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.8.tgz",
-          "integrity": "sha512-BZHKuzV5Mdn+EpC52lFYpd6jUcrL+YQHdq0v0yJfVtpW2ripseQxMGxxXr6Yxp2P4F3g2aY2JrfX2VztosmGLA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/graphics": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.8.tgz",
-          "integrity": "sha512-DUuUXHO4t5fg+n+srMkHX38QEH3WtS1IMXtovBGFJkkopG0Z0xjxSp5XvsPPw1J//4fzkHZI5OBrlN613p9+sg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/interaction": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.8.tgz",
-          "integrity": "sha512-uP247r0f47vo9WSpEnsUfeD1izxVGpjtg4iAyGT/02ezWse2vD1aEL8AbxFa65TL0IXOKsHEQudCVL+wjnbSKQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/loaders": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.8.tgz",
-          "integrity": "sha512-mj11UPKsqWaTEPMpCnFugr6heKkQeNFuVSddSwE8crg19l46zcMhk3ucpQX15RDpAdDJjtl3OraevQCHHbNENw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/math": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.8.tgz",
-          "integrity": "sha512-9493KEH5ITnjOZvQZbaU22lD0kcg/XhNh+309KYfwFX787zA1BN/7is06oHEgHBDb2NemqioYi6sw1WnECgQig==",
-          "dev": true
-        },
-        "@pixi/mesh": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.8.tgz",
-          "integrity": "sha512-iZZGkh8QBhnfMEgpJsuwemFZZVatodckCgj7N8t1hyHEf0aOWEA6wp5N0Osa3mhltokl7BGnZZLxaR8NtjaiEQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mesh-extras": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.8.tgz",
-          "integrity": "sha512-eU2I53yZUFxKbTYZvyRfUcdina3WOl87fyqYwAoaHosU9VgbFl16YADKTGV+NflNp6RCTwU/UIPZ1T19W/iysw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mixin-cache-as-bitmap": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.8.tgz",
-          "integrity": "sha512-5TTv4w8v7guI6z3gKz5ppUCbNMRw+8RRNru/aq65qUl6kcUaJiYwQdBFJ/vJwpI9ePEScWrCuLVEc8QtX6xjNw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mixin-get-child-by-name": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.8.tgz",
-          "integrity": "sha512-b15HTdHpW4ErDBpf7wm1vvWHrTv5kQzElXrwAPBCnLgvronfSL9mL7npOUkZOybUorCoEBq/7oNVjkimsQc5gw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/mixin-get-global-position": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.8.tgz",
-          "integrity": "sha512-Y5epEW5mRrgpDOHvfc92t0PaBgboBKXR4n/AzOOFt0h9GRNTmVKYBpUQPp/HO+r1Bxq+XbaGm1CyfkjUUxnORA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/particle-container": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.8.tgz",
-          "integrity": "sha512-wc4j84PssPWmZLpOJTLLC7MftCULzkQMAfVlwOERhNTZ+6E1LIKw91wDWZe9LQ/20iarzQwQXo0a4uNlJlhnVQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/prepare": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.8.tgz",
-          "integrity": "sha512-anrAcjX3r9ZzK/L6Fw7GhE1pCkjhSfBsxUTlVhuRKJPFC+A3BNpZCwy3GzyvHP4ocl8wvUMzuz5BB5l0AoBCFw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/runner": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.8.tgz",
-          "integrity": "sha512-/9KVgQjTKiBa1qHdNmhP9I+AHgC/Eu9QiKcc+oakLCJtpYi79lx+nDFrpLUamIi2c7lP0hDWVe0XqlQeYmSwag==",
-          "dev": true
-        },
-        "@pixi/settings": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.8.tgz",
-          "integrity": "sha512-gmnwHkg9+tlQRuFNOdimzl73Dup2fdEo/VYaF7spT+8womE4KWAvARCBMqY/10aAx1iYeYuo5av/RfqrePB5Hg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/sprite": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.8.tgz",
-          "integrity": "sha512-ywvbrNgjK+K93X9cvHtDCnsBtU7B9JD/3wg+1G6v1Ktrr2E1gwVIQK1NANBrjzt6cYGphz5EqGAW68d0rMBliw==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/sprite-animated": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.8.tgz",
-          "integrity": "sha512-woPT2cF1BaC0PDWdDrqJ0+DYcyIeXzZLq6bVx2YYia3+jJao1Zjmz1ns5e7YMUTEG7DoVFfhO6CC81YimsMG5w==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/sprite-tiling": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.8.tgz",
-          "integrity": "sha512-PG3tiWI6uUest/d7HAz4/3I8NjpYyeMUL2WDy86nMXCJ6bLdTs/s9Nq3DLckaUsyIMTGsVbj/BXjE8LP1WDTog==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/spritesheet": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.8.tgz",
-          "integrity": "sha512-WiJd4fKpSitD3A+/u5q8IPoHXMFT8++bsluhuJvDwzo//s0PHb9qExlF2xos7zUmekmydEFMkDnrl4+lWn2cyg==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/text": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.8.tgz",
-          "integrity": "sha512-7AZPj5+vWcUjK0QzQ3ehiEwEqywiWR8NhDmnnN5nRNHR9u5IOOnqCQtBTdDffYPN0uMgCi8MzUPwTJhGuyOeww==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/text-bitmap": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.8.tgz",
-          "integrity": "sha512-6VxejDc0gOu5HFN06m6i94xBZHdZ728iao8q+hEOjavGR5i2Pv3xseuke1qY0iN4q6Z+wTkcmoK5BfEVi2ujdQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/ticker": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.8.tgz",
-          "integrity": "sha512-7VKq5hfnRDSv6a16pATqZAmpQfEu4G171iUTloy3QZfbnPw0s3JervZSih1yJJD84GXEF4VzYB26pJ/x3arGjQ==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/utils": {
-          "version": "6.5.8",
-          "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.8.tgz",
-          "integrity": "sha512-zLnvmVQBWPDnwkfvrSpBBF2XpWSMt+kQAsX562eqjuME63ic9M6fK4u/IaA8csdlG2wtcjBvSYWrpWmPq0bWag==",
-          "dev": true,
-          "requires": {
-            "@types/earcut": "^2.1.0",
-            "earcut": "^2.2.4",
-            "eventemitter3": "^3.1.0",
-            "url": "^0.11.0"
-          }
-        }
+        "@pixi/accessibility": "7.0.5",
+        "@pixi/app": "7.0.5",
+        "@pixi/assets": "7.0.5",
+        "@pixi/compressed-textures": "7.0.5",
+        "@pixi/core": "7.0.5",
+        "@pixi/display": "7.0.5",
+        "@pixi/events": "7.0.5",
+        "@pixi/extensions": "7.0.5",
+        "@pixi/extract": "7.0.5",
+        "@pixi/filter-alpha": "7.0.5",
+        "@pixi/filter-blur": "7.0.5",
+        "@pixi/filter-color-matrix": "7.0.5",
+        "@pixi/filter-displacement": "7.0.5",
+        "@pixi/filter-fxaa": "7.0.5",
+        "@pixi/filter-noise": "7.0.5",
+        "@pixi/graphics": "7.0.5",
+        "@pixi/mesh": "7.0.5",
+        "@pixi/mesh-extras": "7.0.5",
+        "@pixi/mixin-cache-as-bitmap": "7.0.5",
+        "@pixi/mixin-get-child-by-name": "7.0.5",
+        "@pixi/mixin-get-global-position": "7.0.5",
+        "@pixi/particle-container": "7.0.5",
+        "@pixi/prepare": "7.0.5",
+        "@pixi/sprite": "7.0.5",
+        "@pixi/sprite-animated": "7.0.5",
+        "@pixi/sprite-tiling": "7.0.5",
+        "@pixi/spritesheet": "7.0.5",
+        "@pixi/text": "7.0.5",
+        "@pixi/text-bitmap": "7.0.5"
       }
     },
     "pkg-dir": {
@@ -38282,12 +38085,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
-      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==",
-      "dev": true
-    },
     "prompts": {
       "version": "2.4.0",
       "dev": true,
@@ -38330,6 +38127,12 @@
     },
     "psl": {
       "version": "1.9.0",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
     },
     "puppeteer-core": {
@@ -38401,6 +38204,8 @@
     },
     "querystring": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "dev": true
     },
     "querystringify": {
@@ -40002,16 +39807,12 @@
     },
     "url": {
       "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "dev": true
-        }
       }
     },
     "url-parse": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "mock-raf": "^1.0.1",
     "pixi-dashed-line": "^1.4.2",
-    "pixi.js": "^6.5.8",
+    "pixi.js": "^7.0.5",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
     "storybook": "^7.0.0-beta.15",
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "pixi-dashed-line": "^1.4.2",
-    "pixi.js": "^6.5.8"
+    "pixi.js": "^7.0.5"
   },
   "dependencies": {
     "@equinor/videx-math": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.3.1",
     "mock-raf": "^1.0.1",
-    "pixi-dashed-line": "^1.4.2",
     "pixi.js": "^7.0.5",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
@@ -95,7 +94,6 @@
     ]
   },
   "peerDependencies": {
-    "pixi-dashed-line": "^1.4.2",
     "pixi.js": "^7.0.5"
   },
   "dependencies": {

--- a/src/layers/SchematicLayer.ts
+++ b/src/layers/SchematicLayer.ts
@@ -1,7 +1,7 @@
 import { max } from 'd3-array';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import { Graphics, groupD8, IPoint, Point, Rectangle, RENDERER_TYPE, SimpleRope, Texture } from 'pixi.js';
-import { DashLine } from 'pixi-dashed-line';
+import { DashLine } from '../vendor/pixi-dashed-line';
 import { LayerOptions, PixiLayer, PixiRenderApplication } from '.';
 import { DEFAULT_TEXTURE_SIZE, EXAGGERATED_DIAMETER, HOLE_OUTLINE, SCREEN_OUTLINE } from '../constants';
 import {

--- a/src/layers/base/PixiLayer.ts
+++ b/src/layers/base/PixiLayer.ts
@@ -1,4 +1,4 @@
-import { AbstractRenderer, Application, autoDetectRenderer, Container, DisplayObject, IRendererOptionsAuto, Renderer, RENDERER_TYPE } from 'pixi.js';
+import { IRenderer, Application, autoDetectRenderer, Container, DisplayObject, IRendererOptionsAuto, Renderer, RENDERER_TYPE } from 'pixi.js';
 import { Layer, LayerOptions } from './Layer';
 import { OnMountEvent, OnRescaleEvent, OnResizeEvent, OnUnmountEvent } from '../../interfaces';
 import { DEFAULT_LAYER_HEIGHT, DEFAULT_LAYER_WIDTH } from '../../constants';
@@ -11,7 +11,7 @@ import { DEFAULT_LAYER_HEIGHT, DEFAULT_LAYER_WIDTH } from '../../constants';
 export class PixiRenderApplication {
   stage: Container;
 
-  renderer: AbstractRenderer;
+  renderer: IRenderer<HTMLCanvasElement>;
 
   constructor(pixiRenderOptions?: IRendererOptionsAuto) {
     const options = {
@@ -24,7 +24,7 @@ export class PixiRenderApplication {
       preserveDrawingBuffer: true,
       ...pixiRenderOptions,
     };
-    this.renderer = autoDetectRenderer(options);
+    this.renderer = autoDetectRenderer<HTMLCanvasElement>(options);
     this.stage = new Container();
   }
 
@@ -68,7 +68,7 @@ export abstract class PixiLayer<T> extends Layer<T> {
   private ctx: PixiRenderApplication;
   private container: Container;
 
-  constructor(ctx: Application | PixiRenderApplication, id?: string, options?: LayerOptions<T>) {
+  constructor(ctx: Application<HTMLCanvasElement> | PixiRenderApplication, id?: string, options?: LayerOptions<T>) {
     super(id, options);
 
     this.ctx = ctx;

--- a/src/vendor/pixi-dashed-line/index.ts
+++ b/src/vendor/pixi-dashed-line/index.ts
@@ -1,0 +1,394 @@
+// https://github.com/davidfig/pixi-dashed-line
+//
+// Copyright 2021 David Figatner
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+// and associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import * as PIXI from 'pixi.js';
+
+/** Define the dash: [dash length, gap size, dash size, gap size, ...] */
+export type Dashes = number[];
+
+export interface DashLineOptions {
+  dash?: Dashes;
+  width?: number;
+  color?: number;
+  alpha?: number;
+  scale?: number;
+  useTexture?: boolean;
+  useDots?: boolean;
+  cap?: PIXI.LINE_CAP;
+  join?: PIXI.LINE_JOIN;
+  alignment?: number;
+}
+
+const dashLineOptionsDefault: Partial<DashLineOptions> = {
+  dash: [10, 5], // eslint-disable-line no-magic-numbers
+  width: 1,
+  color: 0xffffff,
+  alpha: 1,
+  scale: 1,
+  useTexture: false,
+  alignment: 0.5,
+};
+
+export class DashLine {
+  graphics: PIXI.Graphics;
+
+  /** current length of the line */
+  lineLength: number;
+
+  /** cursor location */
+  cursor = new PIXI.Point();
+
+  /** desired scale of line */
+  scale = 1;
+
+  // sanity check to ensure the lineStyle is still in use
+  private activeTexture: PIXI.Texture;
+
+  private start: PIXI.Point;
+
+  private dashSize: number;
+  private dash: number[];
+
+  private useTexture: boolean;
+  private options: DashLineOptions;
+
+  // cache of PIXI.Textures for dashed lines
+  static dashTextureCache: Record<string, PIXI.Texture> = {};
+
+  /**
+   * Create a DashLine
+   * @param graphics
+   * @param [options]
+   * @param [options.useTexture=false] - use the texture based render (useful for very large or very small dashed lines)
+   * @param [options.dashes=[10,5] - an array holding the dash and gap (eg, [10, 5, 20, 5, ...])
+   * @param [options.width=1] - width of the dashed line
+   * @param [options.alpha=1] - alpha of the dashed line
+   * @param [options.color=0xffffff] - color of the dashed line
+   * @param [options.cap] - add a PIXI.LINE_CAP style to dashed lines (only works for useTexture: false)
+   * @param [options.join] - add a PIXI.LINE_JOIN style to the dashed lines (only works for useTexture: false)
+   * @param [options.alignment] - The alignment of any lines drawn (0.5 = middle, 1 = outer, 0 = inner)
+   */
+  constructor(graphics: PIXI.Graphics, options: DashLineOptions = {}) {
+    this.graphics = graphics;
+    options = { ...dashLineOptionsDefault, ...options };
+    this.dash = options.dash;
+    this.dashSize = this.dash.reduce((a, b) => a + b);
+    this.useTexture = options.useTexture;
+    this.options = options;
+    this.setLineStyle();
+  }
+
+  /** resets line style to enable dashed line (useful if lineStyle was changed on graphics element) */
+  setLineStyle() {
+    const options = this.options;
+    if (this.useTexture) {
+      const texture = DashLine.getTexture(options, this.dashSize);
+      this.graphics.lineTextureStyle({
+        width: options.width * options.scale,
+        color: options.color,
+        alpha: options.alpha,
+        texture,
+        alignment: options.alignment,
+      });
+      this.activeTexture = texture;
+    } else {
+      this.graphics.lineStyle({
+        width: options.width * options.scale,
+        color: options.color,
+        alpha: options.alpha,
+        cap: options.cap,
+        join: options.join,
+        alignment: options.alignment,
+      });
+    }
+    this.scale = options.scale;
+  }
+
+  private static distance(x1: number, y1: number, x2: number, y2: number): number {
+    return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+  }
+
+  moveTo(x: number, y: number): this {
+    this.lineLength = 0;
+    this.cursor.set(x, y);
+    this.start = new PIXI.Point(x, y);
+    this.graphics.moveTo(this.cursor.x, this.cursor.y);
+    return this;
+  }
+
+  lineTo(x: number, y: number, closePath?: boolean): this {
+    if (typeof this.lineLength === undefined) {
+      this.moveTo(0, 0);
+    }
+    const length = DashLine.distance(this.cursor.x, this.cursor.y, x, y);
+    const angle = Math.atan2(y - this.cursor.y, x - this.cursor.x);
+    const closed = closePath && x === this.start.x && y === this.start.y;
+    if (this.useTexture) {
+      this.graphics.moveTo(this.cursor.x, this.cursor.y);
+      this.adjustLineStyle(angle);
+      if (closed && this.dash.length % 2 === 0) {
+        const gap = Math.min(this.dash[this.dash.length - 1], length);
+        this.graphics.lineTo(x - Math.cos(angle) * gap, y - Math.sin(angle) * gap);
+        this.graphics.closePath();
+      } else {
+        this.graphics.lineTo(x, y);
+      }
+    } else {
+      const cos = Math.cos(angle);
+      const sin = Math.sin(angle);
+      let x0 = this.cursor.x;
+      let y0 = this.cursor.y;
+
+      // find the first part of the dash for this line
+      const place = this.lineLength % (this.dashSize * this.scale);
+      let dashIndex: number = 0,
+        dashStart: number = 0;
+      let dashX = 0;
+      for (let i = 0; i < this.dash.length; i++) {
+        const dashSize = this.dash[i] * this.scale;
+        if (place < dashX + dashSize) {
+          dashIndex = i;
+          dashStart = place - dashX;
+          break;
+        } else {
+          dashX += dashSize;
+        }
+      }
+
+      let remaining = length;
+      // let count = 0
+      while (remaining > 0) {
+        // && count++ < 1000) {
+        const dashSize = this.dash[dashIndex] * this.scale - dashStart;
+        const dist = remaining > dashSize ? dashSize : remaining;
+        if (closed) {
+          const remainingDistance = DashLine.distance(x0 + cos * dist, y0 + sin * dist, this.start.x, this.start.y);
+          if (remainingDistance <= dist) {
+            if (dashIndex % 2 === 0) {
+              const lastDash = DashLine.distance(x0, y0, this.start.x, this.start.y) - this.dash[this.dash.length - 1] * this.scale;
+              x0 += cos * lastDash;
+              y0 += sin * lastDash;
+              this.graphics.lineTo(x0, y0);
+            }
+            break;
+          }
+        }
+
+        x0 += cos * dist;
+        y0 += sin * dist;
+        if (dashIndex % 2) {
+          this.graphics.moveTo(x0, y0);
+        } else {
+          this.graphics.lineTo(x0, y0);
+        }
+        remaining -= dist;
+
+        dashIndex++;
+        dashIndex = dashIndex === this.dash.length ? 0 : dashIndex;
+        dashStart = 0;
+      }
+      // if (count >= 1000) console.log('failure', this.scale)
+    }
+    this.lineLength += length;
+    this.cursor.set(x, y);
+    return this;
+  }
+
+  closePath() {
+    this.lineTo(this.start.x, this.start.y, true);
+  }
+
+  drawCircle(x: number, y: number, radius: number, points = 80, matrix?: PIXI.Matrix): this {
+    const interval = (Math.PI * 2) / points;
+    let angle = 0,
+      first: PIXI.Point;
+    if (matrix) {
+      first = new PIXI.Point(x + Math.cos(angle) * radius, y + Math.sin(angle) * radius);
+      matrix.apply(first, first);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.moveTo(first[0], first[1]);
+    } else {
+      first = new PIXI.Point(x + Math.cos(angle) * radius, y + Math.sin(angle) * radius);
+      this.moveTo(first.x, first.y);
+    }
+    angle += interval;
+    for (let i = 1; i < points + 1; i++) {
+      const next = i === points ? first : [x + Math.cos(angle) * radius, y + Math.sin(angle) * radius];
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.lineTo(next[0], next[1]);
+      angle += interval;
+    }
+    return this;
+  }
+
+  drawEllipse(x: number, y: number, radiusX: number, radiusY: number, points = 80, matrix?: PIXI.Matrix): this {
+    const interval = (Math.PI * 2) / points;
+    let first: { x: number; y: number };
+    const point = new PIXI.Point();
+    for (let i = 0; i < Math.PI * 2; i += interval) {
+      let x0 = x - radiusX * Math.sin(i);
+      let y0 = y - radiusY * Math.cos(i);
+      if (matrix) {
+        point.set(x0, y0);
+        matrix.apply(point, point);
+        x0 = point.x;
+        y0 = point.y;
+      }
+      if (i === 0) {
+        this.moveTo(x0, y0);
+        first = { x: x0, y: y0 };
+      } else {
+        this.lineTo(x0, y0);
+      }
+    }
+    this.lineTo(first.x, first.y, true);
+    return this;
+  }
+
+  drawPolygon(points: PIXI.Point[] | number[], matrix?: PIXI.Matrix): this {
+    const p = new PIXI.Point();
+    if (typeof points[0] === 'number') {
+      if (matrix) {
+        p.set(points[0] as number, points[1] as number);
+        matrix.apply(p, p);
+        this.moveTo(p.x, p.y);
+        for (let i = 2; i < points.length; i += 2) {
+          p.set(points[i] as number, points[i + 1] as number);
+          matrix.apply(p, p);
+          this.lineTo(p.x, p.y, i === points.length - 2);
+        }
+      } else {
+        this.moveTo(points[0] as number, points[1] as number);
+        for (let i = 2; i < points.length; i += 2) {
+          this.lineTo(points[i] as number, points[i + 1] as number, i === points.length - 2);
+        }
+      }
+    } else {
+      if (matrix) {
+        const point = points[0] as PIXI.Point;
+        p.copyFrom(point);
+        matrix.apply(p, p);
+        this.moveTo(p.x, p.y);
+        for (let i = 1; i < points.length; i++) {
+          const point = points[i] as PIXI.Point;
+          p.copyFrom(point);
+          matrix.apply(p, p);
+          this.lineTo(p.x, p.y, i === points.length - 1);
+        }
+      } else {
+        const point = points[0] as PIXI.Point;
+        this.moveTo(point.x, point.y);
+        for (let i = 1; i < points.length; i++) {
+          const point = points[i] as PIXI.Point;
+          this.lineTo(point.x, point.y, i === points.length - 1);
+        }
+      }
+    }
+    return this;
+  }
+
+  drawRect(x: number, y: number, width: number, height: number, matrix?: PIXI.Matrix): this {
+    if (matrix) {
+      const p = new PIXI.Point();
+
+      // moveTo(x, y)
+      p.set(x, y);
+      matrix.apply(p, p);
+      this.moveTo(p.x, p.y);
+
+      // lineTo(x + width, y)
+      p.set(x + width, y);
+      matrix.apply(p, p);
+      this.lineTo(p.x, p.y);
+
+      // lineTo(x + width, y + height)
+      p.set(x + width, y + height);
+      matrix.apply(p, p);
+      this.lineTo(p.x, p.y);
+
+      // lineto(x, y + height)
+      p.set(x, y + height);
+      matrix.apply(p, p);
+      this.lineTo(p.x, p.y);
+
+      // lineTo(x, y, true)
+      p.set(x, y);
+      matrix.apply(p, p);
+      this.lineTo(p.x, p.y, true);
+    } else {
+      this.moveTo(x, y)
+        .lineTo(x + width, y)
+        .lineTo(x + width, y + height)
+        .lineTo(x, y + height)
+        .lineTo(x, y, true);
+    }
+    return this;
+  }
+
+  // adjust the matrix for the dashed texture
+  private adjustLineStyle(angle: number) {
+    const lineStyle = this.graphics.line;
+    lineStyle.matrix = new PIXI.Matrix();
+    if (angle) {
+      lineStyle.matrix.rotate(angle);
+    }
+    if (this.scale !== 1) {
+      lineStyle.matrix.scale(this.scale, this.scale);
+    }
+    const textureStart = -this.lineLength;
+    lineStyle.matrix.translate(this.cursor.x + textureStart * Math.cos(angle), this.cursor.y + textureStart * Math.sin(angle));
+    this.graphics.lineStyle(lineStyle);
+  }
+
+  // creates or uses cached texture
+  private static getTexture(options: DashLineOptions, dashSize: number): PIXI.Texture {
+    const key = options.dash.toString();
+    if (DashLine.dashTextureCache[key]) {
+      return DashLine.dashTextureCache[key];
+    }
+    const canvas = document.createElement('canvas');
+    canvas.width = dashSize;
+    canvas.height = Math.ceil(options.width);
+    const context = canvas.getContext('2d');
+    if (!context) {
+      console.warn('Did not get context from canvas');
+      return;
+    }
+    context.strokeStyle = 'white';
+    context.globalAlpha = options.alpha;
+    context.lineWidth = options.width;
+    let x = 0;
+    const y = options.width / 2;
+    context.moveTo(x, y);
+    for (let i = 0; i < options.dash.length; i += 2) {
+      x += options.dash[i];
+      context.lineTo(x, y);
+      if (options.dash.length !== i + 1) {
+        x += options.dash[i + 1];
+        context.moveTo(x, y);
+      }
+    }
+    context.stroke();
+    const texture = (DashLine.dashTextureCache[key] = PIXI.Texture.from(canvas));
+    texture.baseTexture.scaleMode = PIXI.SCALE_MODES.NEAREST;
+    return texture;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,6 @@ export default defineConfig({
         sourcemap: true,
         globals: {
           'pixi.js': 'PIXI',
-          'pixi-dashed-line': 'pixiDashedLine',
         },
       },
     },


### PR DESCRIPTION
* update to pixi v7
* vendor pixi-dashed-line package
   pixi-dashed-line depends on pixi v.6 and causes peerDependency conflict when upgrading to PixiJS v7