### PR TITLE
Remove canvas fallback

### DIFF
--- a/src/datautils/schematicShapeGenerator.ts
+++ b/src/datautils/schematicShapeGenerator.ts
@@ -46,7 +46,6 @@ export interface CasingRenderObject {
     leftPath: Point[];
     rightPath: Point[];
     pathPoints: Point[];
-    polygon: IPoint[];
   }[];
 }
 
@@ -61,10 +60,6 @@ export const getEndLines = (
     top: [rightPath[0], leftPath[0]],
     bottom: [rightPath[rightPath.length - 1], leftPath[leftPath.length - 1]],
   };
-};
-
-export const makeTubularPolygon = (rightPath: Point[], leftPath: Point[]): Point[] => {
-  return [...leftPath, ...rightPath.map<Point>((d) => d.clone()).reverse()];
 };
 
 export const overlaps = (top1: number, bottom1: number, top2: number, bottom2: number): boolean => top1 <= bottom2 && top2 <= bottom1;
@@ -567,7 +562,7 @@ export const prepareCasingRenderObject = (
   const sections = getCasingIntervalsWithWindows(casing).map((casingInterval: CasingInterval) => {
     const pathPoints = getPathPoints(casingInterval.start, casingInterval.end);
     const { leftPath, rightPath } = createTubularRenderingObject(exaggeratedRadius, pathPoints);
-    return { kind: casingInterval.kind, leftPath, rightPath, pathPoints, polygon: makeTubularPolygon(leftPath, rightPath) };
+    return { kind: casingInterval.kind, leftPath, rightPath, pathPoints };
   });
 
   return {

--- a/src/layers/SchematicLayer.ts
+++ b/src/layers/SchematicLayer.ts
@@ -263,12 +263,6 @@ export class SchematicLayer<T extends SchematicData> extends PixiLayer<T> {
     this.addChild(polygon);
   };
 
-  protected drawBigTexturedPolygon = (coords: Point[], t: Texture): Graphics => {
-    const polygon = new Graphics().beginTextureFill({ texture: t }).drawPolygon(coords).endFill();
-    this.addChild(polygon);
-    return polygon;
-  };
-
   protected drawRope(path: Point[], texture: Texture, tint?: number): void {
     if (path.length === 0) {
       return null;

--- a/src/layers/SchematicLayer.ts
+++ b/src/layers/SchematicLayer.ts
@@ -1,6 +1,6 @@
 import { max } from 'd3-array';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
-import { Graphics, groupD8, IPoint, Point, Rectangle, RENDERER_TYPE, SimpleRope, Texture } from 'pixi.js';
+import { Graphics, groupD8, IPoint, Point, Rectangle, SimpleRope, Texture } from 'pixi.js';
 import { DashLine } from '../vendor/pixi-dashed-line';
 import { LayerOptions, PixiLayer, PixiRenderApplication } from '.';
 import { DEFAULT_TEXTURE_SIZE, EXAGGERATED_DIAMETER, HOLE_OUTLINE, SCREEN_OUTLINE } from '../constants';
@@ -56,7 +56,6 @@ import {
   createScreenTexture,
   createTubingTexture,
   createTubularRenderingObject,
-  makeTubularPolygon,
   prepareCasingRenderObject,
   createCementPlugTexture,
   createComplexRopeSegmentsForPerforation,
@@ -632,14 +631,9 @@ export class SchematicLayer<T extends SchematicData> extends PixiLayer<T> {
     const { exaggerationFactor, holeOptions } = this.options as SchematicLayerOptions<T>;
     const exaggeratedDiameter = holeObject.diameter * exaggerationFactor;
     const { rightPath, leftPath } = createTubularRenderingObject(exaggeratedDiameter / 2, pathPoints);
+    const texture = this.getHoleTexture(holeOptions, exaggeratedDiameter, maxHoleDiameter);
 
-    if (this.renderType() === RENDERER_TYPE.CANVAS) {
-      const polygonCoords = makeTubularPolygon(leftPath, rightPath);
-      this.drawBigPolygon(polygonCoords, convertColor(holeOptions.firstColor));
-    } else {
-      const texture = this.getHoleTexture(holeOptions, exaggeratedDiameter, maxHoleDiameter);
-      this.drawHoleRope(pathPoints, texture, maxHoleDiameter);
-    }
+    this.drawHoleRope(pathPoints, texture, maxHoleDiameter);
 
     this.drawOutline(leftPath, rightPath, convertColor(holeOptions.lineColor), HOLE_OUTLINE * exaggerationFactor, 'TopAndBottom', 0);
   };
@@ -759,13 +753,10 @@ export class SchematicLayer<T extends SchematicData> extends PixiLayer<T> {
 
     casingRenderObject.sections.forEach((section, index, list) => {
       const outlineClosureType = SchematicLayer.getOutlineClosureType(index, list.length - 1);
-      // Pixi.js-legacy handles SimpleRope and advanced render methods poorly
-      if (this.renderType() === RENDERER_TYPE.CANVAS) {
-        this.drawBigPolygon(section.polygon, casingSolidColorNumber);
-      } else {
-        const texture = this.createCasingTexture(casingRenderObject.referenceDiameter);
-        this.drawRope(section.pathPoints, texture, casingSolidColorNumber);
-      }
+
+      const texture = this.createCasingTexture(casingRenderObject.referenceDiameter);
+      this.drawRope(section.pathPoints, texture, casingSolidColorNumber);
+
       if (section.kind === 'casing-window') {
         this.drawCasingWindowOutline(section.leftPath, section.rightPath, casingOptions, casingRenderObject.casingWallWidth);
       } else {
@@ -843,14 +834,10 @@ export class SchematicLayer<T extends SchematicData> extends PixiLayer<T> {
 
     const pathPoints = this.getZFactorScaledPathForPoints(start, end);
     const { leftPath, rightPath } = createTubularRenderingObject(exaggeratedDiameter / 2, pathPoints);
-    const polygon = makeTubularPolygon(leftPath, rightPath);
 
     const texture = this.getScreenTexture();
-    if (this.renderType() === RENDERER_TYPE.CANVAS) {
-      this.drawBigTexturedPolygon(polygon, texture);
-    } else {
-      this.drawCompletionRope(pathPoints, texture, exaggeratedDiameter);
-    }
+
+    this.drawCompletionRope(pathPoints, texture, exaggeratedDiameter);
     this.drawOutline(leftPath, rightPath, convertColor(screenOptions.lineColor), SCREEN_OUTLINE * exaggerationFactor, 'TopAndBottom');
   }
 
@@ -859,15 +846,9 @@ export class SchematicLayer<T extends SchematicData> extends PixiLayer<T> {
     const exaggeratedDiameter = exaggerationFactor * diameter;
 
     const pathPoints = this.getZFactorScaledPathForPoints(start, end);
-    const { leftPath, rightPath } = createTubularRenderingObject(exaggeratedDiameter / 2, pathPoints);
-    const polygon = makeTubularPolygon(leftPath, rightPath);
-
     const texture = this.getTubingTexture(tubingOptions);
-    if (this.renderType() === RENDERER_TYPE.CANVAS) {
-      this.drawBigTexturedPolygon(polygon, texture);
-    } else {
-      this.drawCompletionRope(pathPoints, texture, exaggeratedDiameter);
-    }
+
+    this.drawCompletionRope(pathPoints, texture, exaggeratedDiameter);
   }
 
   private getTubingTexture(tubingOptions: TubingOptions): Texture {


### PR DESCRIPTION
Remove non-WebGL fallback code in SchematicLayer since Chrome/Edge's Swift renderer (software CPU renderer) is fast enough and produces perfect results.

Issue: https://github.com/equinor/esv-intersection/issues/535