### PR TITLE
chore: enable Typescript's strict mode

### DIFF
--- a/.changeset/thin-experts-confess.md
+++ b/.changeset/thin-experts-confess.md
@@ -2,4 +2,4 @@
 "@equinor/esv-intersection": patch
 ---
 
-chore: enable Typescript's strict mode
+chore: enable Typescript's strict mode & fix 1500 errors

--- a/.changeset/thin-experts-confess.md
+++ b/.changeset/thin-experts-confess.md
@@ -1,0 +1,5 @@
+---
+"@equinor/esv-intersection": patch
+---
+
+chore: enable Typescript's strict mode

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,27 +13,8 @@
     "SharedArrayBuffer": "readonly"
   },
   "rules": {
-    "prettier/prettier": "error",
-
-    "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-empty-interface": "off",
-    "@typescript-eslint/no-inferrable-types": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
-    "@typescript-eslint/no-use-before-define": "off",
-
-    "curly": "error",
-    "no-continue": "off",
-    "no-plusplus": "off",
-    "no-param-reassign": "off",
-    "object-curly-newline": "off",
-    "no-underscore-dangle": "off",
-    "quotes": ["error", "single"],
-    "import/prefer-default-export": "off",
-    "max-len": ["error", { "code": 150 }],
-    "comma-dangle": ["error", "always-multiline"],
-    "eqeqeq": ["error", "always", { "null": "ignore" }],
-    "no-magic-numbers": ["error", { "ignore": [-1, 0, 0.5, 1, 2, 3, 4, 8, 16, 100, 255, 1000], "ignoreDefaultValues": true }],
-    "newline-per-chained-call": ["off", { "ignoreChainWithDepth": 1 }],
-    "no-warning-comments": [0, { "terms": ["todo", "fixme"], "location": "start" }]
+    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/no-namespace": "warn",
+    "@typescript-eslint/no-unused-vars": ["error", { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,34 @@
   "rules": {
     "@typescript-eslint/ban-ts-comment": "warn",
     "@typescript-eslint/no-namespace": "warn",
-    "@typescript-eslint/no-unused-vars": ["error", { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }]
+    "@typescript-eslint/no-unused-vars": ["error", { "args": "all", "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }],
+
+    /* NOTE(Kevin): Currently needed after enabling strict mode, as there were over 1500 Typescript errors.
+     *
+     * Fixing all these errors properly, would
+     * 1) result in a necessary api changes with regards to most of the public interfaces
+     * 2) require drastic changes in implementation details, with an even higher risk
+     * of introducing regressions.
+     *
+     * Therefore I opted to make minimal implementation detail changes in attempt to not
+     * break existing code, while still adhering to Typescript's strict mode.
+
+     * But why enable strict mode?
+     * We've seen a couple bugs now that could have been prevented with strict mode. So
+     * everywhere in the code where there isn't heavily escaped code with `?` or `!` to
+     * force a `fake, correct type` the Typescript compiler will catch those mistakes.
+     * However, type mismatches might still happen in these cases where there's heavy use
+     * of `?` and `!` and those typing mistakes were already existing bugs, that were
+     * waiting to be fixed regardless. Once these bug surface in these areas, it's desired
+     * to remove the `!` and properly fix the types on a case by case basis.
+
+     * These eslint below are metrics in form of warnings on how these are progressing.
+     * The initial warning amount is 297 warnings, slowly this number should be decreasing,
+     * as usage of `!` is not recommended and an escape hatch we needed in order to enable
+     * strict typing on all the other areas of the codebase.
+     *
+     */
+    "@typescript-eslint/no-non-null-assertion": "warn",
+    "@typescript-eslint/no-non-null-asserted-optional-chain": "warn"
   }
 }

--- a/src/components/axis.ts
+++ b/src/components/axis.ts
@@ -1,5 +1,5 @@
 import { axisRight, axisBottom } from 'd3-axis';
-import { BaseType, Selection } from 'd3-selection';
+import { Selection } from 'd3-selection';
 import { ScaleLinear, scaleLinear } from 'd3-scale';
 import { OnResizeEvent, OnRescaleEvent } from '../interfaces';
 
@@ -44,12 +44,12 @@ export class Axis {
     this._scaleY = scaleLinear().domain([0, 1]).range([0, 1]);
   }
 
-  private renderLabelx(): Selection<BaseType, unknown, null, undefined> {
+  private renderLabelx(): Selection<SVGTextElement, unknown, null, undefined> {
     const { _labelXDesc: labelXDesc, _unitOfMeasure: unitOfMeasure, _showLabels, _scaleX: scaleX } = this;
     const [, width] = scaleX.range();
     const gx = this.renderGx();
 
-    let labelx = gx.select('text.axis-labelx');
+    let labelx: Selection<SVGTextElement, unknown, null, undefined> = gx.select('text.axis-labelx');
     if (_showLabels) {
       if (labelx.empty()) {
         labelx = gx
@@ -64,16 +64,16 @@ export class Axis {
     } else {
       labelx.remove();
     }
-    labelx.attr('transform', `translate(${width / 2},-4)`);
+    labelx.attr('transform', `translate(${width! / 2},-4)`);
     return labelx;
   }
 
-  private renderLabely(): Selection<BaseType, unknown, null, undefined> {
+  private renderLabely(): Selection<SVGTextElement, unknown, null, undefined> {
     const { _labelYDesc: labelYDesc, _unitOfMeasure: unitOfMeasure, _showLabels, _scaleY } = this;
     const [, height] = _scaleY.range();
     const gy = this.renderGy();
 
-    let labely = gy.select('text.axis-labely');
+    let labely: Selection<SVGTextElement, unknown, null, undefined> = gy.select('text.axis-labely');
     if (_showLabels) {
       if (labely.empty()) {
         labely = gy
@@ -85,16 +85,16 @@ export class Axis {
           .style('font-size', '10px')
           .text(`${labelYDesc} (${unitOfMeasure})`);
       }
-      labely.attr('transform', `translate(-10,${height / 2})rotate(90)`);
+      labely.attr('transform', `translate(-10,${height! / 2})rotate(90)`);
     } else {
       labely.remove();
     }
     return labely;
   }
 
-  private renderGy(): Selection<BaseType, unknown, null, undefined> {
+  private renderGy(): Selection<SVGGElement, unknown, null, undefined> {
     const { _scaleX, _scaleY } = this;
-    const yAxis = axisRight(_scaleY) as (selection: Selection<SVGSVGElement, unknown, null, undefined>) => void;
+    const yAxis = axisRight(_scaleY) as (selection: Selection<SVGGElement, unknown, null, undefined>, ...args: any[]) => void;
     const [, width] = _scaleX.range();
     const gy = this.createOrGet('y-axis');
     gy.call(yAxis);
@@ -103,9 +103,9 @@ export class Axis {
     return gy;
   }
 
-  private renderGx(): Selection<BaseType, unknown, null, undefined> {
+  private renderGx(): Selection<SVGGElement, unknown, null, undefined> {
     const { _scaleX, _scaleY } = this;
-    const xAxis = axisBottom(_scaleX) as (selection: Selection<SVGSVGElement, unknown, null, undefined>) => void;
+    const xAxis = axisBottom(_scaleX) as (selection: Selection<SVGGElement, unknown, null, undefined>, ...args: any[]) => void;
     const [, height] = _scaleY.range();
 
     const gx = this.createOrGet('x-axis');
@@ -114,9 +114,9 @@ export class Axis {
     return gx;
   }
 
-  private createOrGet = (name: string): Selection<BaseType, unknown, null, undefined> => {
+  private createOrGet = (name: string): Selection<SVGGElement, unknown, null, undefined> => {
     const { mainGroup } = this;
-    let res = mainGroup.select(`g.${name}`);
+    let res: Selection<SVGGElement, unknown, null, undefined> = mainGroup.select(`g.${name}`);
     if (res.empty()) {
       res = mainGroup.append('g').attr('class', name);
     }
@@ -135,8 +135,8 @@ export class Axis {
   onRescale(event: OnRescaleEvent): void {
     const { _scaleX, _scaleY, offsetX, offsetY } = this;
     const { xScale, yScale } = event;
-    const xBounds = xScale.domain();
-    const yBounds = yScale.domain();
+    const xBounds = xScale.domain() as [number, number];
+    const yBounds = yScale.domain() as [number, number];
 
     const xRange = xScale.range();
     const yRange = yScale.range();
@@ -166,7 +166,7 @@ export class Axis {
 
   flipX(flipX: boolean): Axis {
     this._flipX = flipX;
-    const domain = this._scaleX.domain();
+    const domain = this._scaleX.domain() as [number, number];
     const flip = flipX ? -1 : 1;
     this._scaleX.domain([flip * domain[0], flip * domain[1]]);
     return this;
@@ -174,7 +174,7 @@ export class Axis {
 
   flipY(flipY: boolean): Axis {
     this._flipY = flipY;
-    const domain = this._scaleY.domain();
+    const domain = this._scaleY.domain() as [number, number];
     const flip = flipY ? -1 : 1;
     this._scaleY.domain([flip * domain[0], flip * domain[1]]);
     return this;

--- a/src/components/axis.ts
+++ b/src/components/axis.ts
@@ -17,11 +17,11 @@ export class Axis {
   private _labelXDesc: string;
   private _labelYDesc: string;
   private _unitOfMeasure: string;
-  private _offsetX: number = 0;
-  private _offsetY: number = 0;
+  private _offsetX = 0;
+  private _offsetY = 0;
   private _flipX = false;
   private _flipY = false;
-  private visible: boolean = true;
+  private visible = true;
 
   constructor(mainGroup: Axis['mainGroup'], showLabels = true, labelXDesc: string, labelYDesc: string, unitOfMeasure: string, options?: Options) {
     this.mainGroup = mainGroup;

--- a/src/components/axis.ts
+++ b/src/components/axis.ts
@@ -10,7 +10,7 @@ export type Options = {
 };
 
 export class Axis {
-  private mainGroup: Selection<SVGElement, unknown, null, undefined>;
+  private mainGroup: Selection<SVGSVGElement, unknown, null, undefined>;
   private _scaleX: ScaleLinear<number, number>;
   private _scaleY: ScaleLinear<number, number>;
   private _showLabels = true;
@@ -23,14 +23,7 @@ export class Axis {
   private _flipY = false;
   private visible: boolean = true;
 
-  constructor(
-    mainGroup: Selection<SVGElement, unknown, null, undefined>,
-    showLabels = true,
-    labelXDesc: string,
-    labelYDesc: string,
-    unitOfMeasure: string,
-    options?: Options,
-  ) {
+  constructor(mainGroup: Axis['mainGroup'], showLabels = true, labelXDesc: string, labelYDesc: string, unitOfMeasure: string, options?: Options) {
     this.mainGroup = mainGroup;
     this._showLabels = showLabels;
     this._labelXDesc = labelXDesc;

--- a/src/control/ExtendedCurveInterpolator.ts
+++ b/src/control/ExtendedCurveInterpolator.ts
@@ -78,8 +78,8 @@ export class ExtendedCurveInterpolator extends CurveInterpolator {
       this.generateArcLengthLookup();
     }
     const index = BinarySearch.search(this.arcLengthLookup, arcLength);
-    const v1 = this.arcLengthLookup[index];
-    const v2 = this.arcLengthLookup[index + 1];
+    const v1 = this.arcLengthLookup[index]!;
+    const v2 = this.arcLengthLookup[index + 1]!;
     const t = (index + (arcLength - v1) / (v2 - v1)) / this.arcLengthLookup.length;
     return t;
   }
@@ -123,15 +123,15 @@ export class ExtendedCurveInterpolator extends CurveInterpolator {
 
     if (from !== 0) {
       const fromIndex = Math.floor(from * this.arcLengthLookup.length);
-      const fromLl = this.arcLengthLookup[fromIndex];
-      const fromLh = this.arcLengthLookup[fromIndex + 1];
+      const fromLl = this.arcLengthLookup[fromIndex]!;
+      const fromLh = this.arcLengthLookup[fromIndex + 1]!;
       fromLength = fromLl + ((from * this.arcLengthLookup.length) % this.arcLengthLookup.length) * (fromLh - fromLl);
     }
 
     if (to !== 1) {
       const toIndex = Math.floor(to * this.arcLengthLookup.length);
-      const toLl = this.arcLengthLookup[toIndex];
-      const toLh = this.arcLengthLookup[toIndex + 1];
+      const toLl = this.arcLengthLookup[toIndex]!;
+      const toLh = this.arcLengthLookup[toIndex + 1]!;
       toLength = toLl + ((from * this.arcLengthLookup.length) % this.arcLengthLookup.length) * (toLh - toLl);
     }
 

--- a/src/control/ExtendedCurveInterpolator.ts
+++ b/src/control/ExtendedCurveInterpolator.ts
@@ -84,7 +84,7 @@ export class ExtendedCurveInterpolator extends CurveInterpolator {
     return t;
   }
 
-  generateArcLengthLookup(segments: number = 1000): void {
+  generateArcLengthLookup(segments = 1000): void {
     let lastPos = this.getPointAt(0);
     let length = 0;
     for (let i = 0; i < segments; i++) {

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -42,12 +42,6 @@ export class IntersectionReferenceSystem {
 
   projectedPath: number[][] = [];
 
-  // TODO(Kevin): Possibly not needed anymore
-  projectedTrajectory: number[][];
-  depthReference: number;
-  wellboreId: number;
-  trajectoryOffset: number;
-
   private _offset: number = 0;
 
   displacement!: number;

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -36,31 +36,29 @@ export interface ReferenceSystemOptions {
 }
 
 export class IntersectionReferenceSystem {
-  options: ReferenceSystemOptions;
+  options!: ReferenceSystemOptions;
 
   path: number[][] = [];
 
   projectedPath: number[][] = [];
 
+  // TODO(Kevin): Possibly not needed anymore
   projectedTrajectory: number[][];
+  depthReference: number;
+  wellboreId: number;
+  trajectoryOffset: number;
 
   private _offset: number = 0;
 
-  displacement: number;
+  displacement!: number;
 
-  depthReference: number;
+  interpolators!: Interpolators;
 
-  wellboreId: number;
+  startVector!: number[];
 
-  trajectoryOffset: number;
+  endVector!: number[];
 
-  interpolators: Interpolators;
-
-  startVector: number[];
-
-  endVector: number[];
-
-  _curtainPathCache: MDPoint[];
+  _curtainPathCache: MDPoint[] | undefined;
 
   /**
    * Creates a common reference system that layers and other components can use
@@ -93,15 +91,15 @@ export class IntersectionReferenceSystem {
 
     this.projectedPath = IntersectionReferenceSystem.toDisplacement(path);
 
-    const [displacement] = this.projectedPath[this.projectedPath.length - 1];
-    this.displacement = displacement;
+    const [displacement] = this.projectedPath[this.projectedPath.length - 1]!;
+    this.displacement = displacement!;
 
     this.interpolators = {
       curve: options.curveInterpolator || new ExtendedCurveInterpolator(path),
       trajectory:
         options.trajectoryInterpolator ||
         new ExtendedCurveInterpolator(
-          path.map((d: number[]) => [d[0], d[1]]),
+          path.map((d: number[]) => [d[0]!, d[1]!]),
           { tension: tension || TENSION, arcDivisions: arcDivisions || ARC_DIVISIONS },
         ),
       curtain:
@@ -160,7 +158,7 @@ export class IntersectionReferenceSystem {
       let prevAngle = Math.PI * 2; // Always add first point
       for (let i = this._offset; i <= this.length + this._offset; i += CURTAIN_SAMPLING_INTERVAL) {
         const point = this.project(i);
-        const angle = Math.atan2(point[1], point[0]);
+        const angle = Math.atan2(point[1]!, point[0]!);
 
         // Reduce number of points on a straight line by angle since last point
         if (Math.abs(angle - prevAngle) > CURTAIN_SAMPLING_ANGLE_THRESHOLD) {
@@ -183,7 +181,7 @@ export class IntersectionReferenceSystem {
   /**
    * Map a displacement back to length along the curve
    */
-  unproject(displacement: number): number {
+  unproject(displacement: number): number | undefined {
     const { normalizedLength, calculateDisplacementFromBottom } = this.options;
     const displacementFromStart = calculateDisplacementFromBottom ? this.displacement - displacement : displacement;
     const length = normalizedLength || this.length;
@@ -197,9 +195,9 @@ export class IntersectionReferenceSystem {
 
     const ls = this.interpolators.curtain.getIntersectsAsPositions(displacementFromStart, 0, 1);
     if (ls && ls.length) {
-      return ls[0] * length + this._offset;
+      return ls[0]! * length + this._offset;
     }
-    return null;
+    return undefined;
   }
 
   /**
@@ -208,7 +206,7 @@ export class IntersectionReferenceSystem {
   getProjectedLength(length: number): number {
     const { curtain } = this.interpolators;
     const pl = this.project(length);
-    const l = pl[0] / curtain.maxX;
+    const l = pl[0]! / curtain.maxX;
     return Number.isFinite(l) ? clamp(l, 0, 1) : 0;
   }
 
@@ -229,21 +227,21 @@ export class IntersectionReferenceSystem {
     const extensionStart = from < 0 ? -from : 0;
     const extensionEnd = to > 1 ? to - 1 : 0;
 
-    const refStart = this.interpolators.trajectory.getPointAt(0) as number[];
-    const refEnd = this.interpolators.trajectory.getPointAt(1) as number[];
+    const refStart = this.interpolators.trajectory.getPointAt(0) as [number, number];
+    const refEnd = this.interpolators.trajectory.getPointAt(1) as [number, number];
 
-    let p0;
-    let p3;
+    let p0: [number, number];
+    let p3: [number, number];
     let offset = 0;
     const t0 = Math.max(0, from);
     const t1 = Math.min(1, to);
-    const p1 = this.interpolators.trajectory.getPointAt(t0) as number[];
-    const p2 = this.interpolators.trajectory.getPointAt(t1) as number[];
+    const p1 = this.interpolators.trajectory.getPointAt(t0) as [number, number];
+    const p2 = this.interpolators.trajectory.getPointAt(t1) as [number, number];
 
     if (extensionStart) {
       p0 = [
-        refStart[0] + this.startVector[0] * extensionStart * this.displacement,
-        refStart[1] + this.startVector[1] * extensionStart * this.displacement,
+        refStart[0] + this.startVector[0]! * extensionStart * this.displacement,
+        refStart[1] + this.startVector[1]! * extensionStart * this.displacement,
       ];
       offset = -Vector2.distance(p0, refStart);
     } else if (from > 0) {
@@ -251,7 +249,7 @@ export class IntersectionReferenceSystem {
     }
 
     if (extensionEnd) {
-      p3 = [refEnd[0] + this.endVector[0] * extensionEnd * this.displacement, refEnd[1] + this.endVector[1] * extensionEnd * this.displacement];
+      p3 = [refEnd[0] + this.endVector[0]! * extensionEnd * this.displacement, refEnd[1] + this.endVector[1]! * extensionEnd * this.displacement];
     }
     const points = [];
     const tl = to - from;
@@ -259,19 +257,19 @@ export class IntersectionReferenceSystem {
     const curveSteps = Math.ceil(((t1 - t0) / tl) * steps);
     const postSteps = steps - curveSteps - preSteps;
 
-    if (p0) {
+    if (p0!) {
       points.push(p0);
       for (let i = 1; i < preSteps; i++) {
         const f = (i / preSteps) * extensionStart * this.displacement;
-        points.push([p0[0] - this.startVector[0] * f, p0[1] - this.startVector[1] * f]);
+        points.push([p0[0] - this.startVector[0]! * f, p0[1] - this.startVector[1]! * f]);
       }
     }
     const curvePoints = this.interpolators.trajectory.getPoints(curveSteps - 1, null, t0, t1) as number[][]; // returns steps + 1 points
     points.push(...curvePoints);
-    if (p3) {
+    if (p3!) {
       for (let i = 1; i < postSteps - 1; i++) {
         const f = (i / postSteps) * extensionEnd * this.displacement;
-        points.push([p2[0] + this.endVector[0] * f, p2[1] + this.endVector[1] * f]);
+        points.push([p2[0] + this.endVector[0]! * f, p2[1] + this.endVector[1]! * f]);
       }
       points.push(p3);
     }
@@ -330,7 +328,7 @@ export class IntersectionReferenceSystem {
   getTrajectoryVector(): number[] {
     const { trajectoryAngle, calculateDisplacementFromBottom } = this.options;
 
-    if (isFinite(trajectoryAngle)) {
+    if (trajectoryAngle != null && isFinite(trajectoryAngle)) {
       const angleInRad = radians(trajectoryAngle);
       return new Vector2(Math.cos(angleInRad), Math.sin(angleInRad)).toArray();
     }
@@ -351,11 +349,11 @@ export class IntersectionReferenceSystem {
    * @returns {array}
    */
   static toDisplacement(points: number[][], offset = 0): number[][] {
-    let p0: number[] = points[0];
+    let p0: number[] = points[0]!;
     let l = 0;
     const projected = points.map((p1: number[]) => {
-      const dx = p1[0] - p0[0];
-      const dy = p1[1] - p0[1];
+      const dx = p1[0]! - p0[0]!;
+      const dy = p1[1]! - p0[1]!;
       l += Math.sqrt(dx ** 2 + dy ** 2);
       p0 = p1;
       return [offset > 0 ? offset - l : l, p1[2] || 0];
@@ -377,7 +375,7 @@ export class IntersectionReferenceSystem {
   }
 
   get length(): number {
-    return this.interpolators.curve.length;
+    return this.interpolators.curve?.length ?? 0;
   }
 
   get offset(): number {

--- a/src/control/IntersectionReferenceSystem.ts
+++ b/src/control/IntersectionReferenceSystem.ts
@@ -42,7 +42,7 @@ export class IntersectionReferenceSystem {
 
   projectedPath: number[][] = [];
 
-  private _offset: number = 0;
+  private _offset = 0;
 
   displacement!: number;
 

--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -71,7 +71,7 @@ export class LayerManager {
    * Clears data from all mounted layers
    * @param includeReferenceSystem - (optional) if true also removes reference system, default is true
    */
-  clearAllData(includeReferenceSystem: boolean = true): LayerManager {
+  clearAllData(includeReferenceSystem = true): LayerManager {
     this.layers.forEach((l) => l.clearData(includeReferenceSystem));
     return this;
   }

--- a/src/control/LayerManager.ts
+++ b/src/control/LayerManager.ts
@@ -16,8 +16,8 @@ export class LayerManager {
 
   private layers: Layer<unknown>[] = [];
 
-  private _axis: Axis;
-  private _svgContainer: Selection<HTMLElement, unknown, null, undefined>;
+  private _axis: Axis | undefined;
+  private _svgContainer: Selection<HTMLDivElement, unknown, null, undefined> | undefined;
 
   /**
    * Handles layers and axis also holds a zoom and pan handler object
@@ -30,7 +30,7 @@ export class LayerManager {
     this.layerContainer = document.createElement('div');
     this.layerContainer.className = 'layer-container';
     this.container.appendChild(this.layerContainer);
-    this.adjustToSize(+this.container.getAttribute('width'), +this.container.getAttribute('height'));
+    this.adjustToSize(+(this.container.getAttribute('width') ?? 0), +(this.container.getAttribute('height') ?? 0));
     this._zoomPanHandler = new ZoomPanHandler(container, (event) => this.rescale(event));
     if (scaleOptions) {
       const { xMin, xMax, yMin, yMax, xBounds, yBounds } = scaleOptions;
@@ -113,7 +113,7 @@ export class LayerManager {
     return this;
   }
 
-  getLayer(layerId: string): Layer<unknown> {
+  getLayer(layerId: string): Layer<unknown> | undefined {
     return this.layers.find((l) => l.id === layerId || l.getInternalLayerIds().includes(layerId));
   }
 
@@ -181,51 +181,57 @@ export class LayerManager {
   }
 
   showAxis(): LayerManager {
-    this._axis.show();
+    this._axis?.show();
     return this;
   }
 
   hideAxis(): LayerManager {
-    this._axis.hide();
+    this._axis?.hide();
     return this;
   }
 
   showAxisLabels(): LayerManager {
-    this._axis.showLabels();
+    this._axis?.showLabels();
     return this;
   }
 
   hideAxisLabels(): LayerManager {
-    this._axis.hideLabels();
+    this._axis?.hideLabels();
     return this;
   }
 
   setAxisOffset(x: number, y: number): LayerManager {
-    this._axis.offsetX = x;
-    this._axis.offsetY = y;
-    const gridLayers = this.layers.filter((l: Layer<unknown>) => l instanceof GridLayer);
-    gridLayers.forEach((l: GridLayer<unknown>) => {
-      l.offsetX = x;
-      l.offsetY = y;
-    });
+    if (this._axis) {
+      this._axis.offsetX = x;
+      this._axis.offsetY = y;
+      const gridLayers = this.layers.filter((l: Layer<unknown>): l is GridLayer<unknown> => l instanceof GridLayer);
+      gridLayers.forEach((l: GridLayer<unknown>) => {
+        l.offsetX = x;
+        l.offsetY = y;
+      });
+    }
     return this;
   }
 
   setXAxisOffset(x: number): LayerManager {
-    this._axis.offsetX = x;
-    const gridLayers = this.layers.filter((l: Layer<unknown>) => l instanceof GridLayer);
-    gridLayers.forEach((l: GridLayer<unknown>) => {
-      l.offsetX = x;
-    });
+    if (this._axis) {
+      this._axis.offsetX = x;
+      const gridLayers = this.layers.filter((l: Layer<unknown>): l is GridLayer<unknown> => l instanceof GridLayer);
+      gridLayers.forEach((l: GridLayer<unknown>) => {
+        l.offsetX = x;
+      });
+    }
     return this;
   }
 
   setYAxisOffset(y: number): LayerManager {
-    this._axis.offsetY = y;
-    const gridLayers = this.layers.filter((l: Layer<unknown>) => l instanceof GridLayer);
-    gridLayers.forEach((l: GridLayer<unknown>) => {
-      l.offsetY = y;
-    });
+    if (this._axis) {
+      this._axis.offsetY = y;
+      const gridLayers = this.layers.filter((l: Layer<unknown>): l is GridLayer<unknown> => l instanceof GridLayer);
+      gridLayers.forEach((l: GridLayer<unknown>) => {
+        l.offsetY = y;
+      });
+    }
     return this;
   }
 
@@ -247,10 +253,6 @@ export class LayerManager {
   destroy(): LayerManager {
     this.removeAllLayers();
     this.layerContainer.remove();
-    this.layerContainer = undefined;
-    this.container = undefined;
-    this.layers = undefined;
-    this._zoomPanHandler = undefined;
     this._axis = undefined;
     this._svgContainer = undefined;
 
@@ -261,7 +263,7 @@ export class LayerManager {
     return this._zoomPanHandler;
   }
 
-  get axis(): Axis {
+  get axis(): Axis | undefined {
     return this._axis;
   }
 

--- a/src/control/MainController.ts
+++ b/src/control/MainController.ts
@@ -12,7 +12,7 @@ import { HORIZONTAL_AXIS_MARGIN, VERTICAL_AXIS_MARGIN } from '../constants';
  * API for controlling data and layers
  */
 export class Controller {
-  private _referenceSystem: IntersectionReferenceSystem;
+  private _referenceSystem: IntersectionReferenceSystem | undefined;
 
   private layerManager: LayerManager;
   private _overlay: Overlay<Controller>;
@@ -106,7 +106,7 @@ export class Controller {
    * Find first layer with given id, returns undefined if none are found
    * @param layerId string id
    */
-  getLayer(layerId: string): Layer<unknown> {
+  getLayer(layerId: string): Layer<unknown> | undefined {
     return this.layerManager.getLayer(layerId);
   }
 
@@ -259,8 +259,6 @@ export class Controller {
     this.layerManager.destroy();
     this._overlay.destroy();
     this._referenceSystem = undefined;
-    this.layerManager = undefined;
-    this._overlay = undefined;
     return this;
   }
 
@@ -278,7 +276,7 @@ export class Controller {
     return this._overlay;
   }
 
-  get referenceSystem(): IntersectionReferenceSystem {
+  get referenceSystem(): IntersectionReferenceSystem | undefined {
     return this._referenceSystem;
   }
 
@@ -286,7 +284,7 @@ export class Controller {
     return this.layerManager.zoomPanHandler;
   }
 
-  get axis(): Axis {
+  get axis(): Axis | undefined {
     return this.layerManager.axis;
   }
 

--- a/src/control/MainController.ts
+++ b/src/control/MainController.ts
@@ -69,7 +69,7 @@ export class Controller {
    * Clears data from all mounted layers
    * @param includeReferenceSystem - (optional) if true also removes reference system, default is true
    */
-  clearAllData(includeReferenceSystem: boolean = true): Controller {
+  clearAllData(includeReferenceSystem = true): Controller {
     this.layerManager.clearAllData(includeReferenceSystem);
     return this;
   }

--- a/src/control/ZoomPanHandler.ts
+++ b/src/control/ZoomPanHandler.ts
@@ -12,20 +12,19 @@ export type RescaleFunction = (event: OnRescaleEvent) => void;
  * Handle zoom and pan for intersection layers
  */
 export class ZoomPanHandler {
-  zoom: ZoomBehavior<Element, unknown> = null;
-  elm: HTMLElement = null;
-  container: Selection<HTMLElement, unknown, null, undefined> = null;
-  onRescale: RescaleFunction = null;
-  options: ZoomAndPanOptions = null;
+  zoom!: ZoomBehavior<HTMLElement, unknown>;
+  container: Selection<HTMLElement, unknown, null, undefined>;
+  onRescale: RescaleFunction;
+  options: ZoomAndPanOptions;
   xBounds: [number, number] = [0, 1];
   yBounds: [number, number] = [0, 1];
   translateBoundsX: [number, number] = [0, 1];
   translateBoundsY: [number, number] = [0, 1];
-  scaleX: ScaleLinear<number, number> = null;
-  scaleY: ScaleLinear<number, number> = null;
+  scaleX: ScaleLinear<number, number>;
+  scaleY: ScaleLinear<number, number>;
   _zFactor: number = 1;
-  _enableTranslateExtent: boolean;
-  currentTransform: ZoomTransform;
+  _enableTranslateExtent: boolean = false;
+  currentTransform: ZoomTransform | undefined;
 
   /**
    * Constructor
@@ -66,7 +65,7 @@ export class ZoomPanHandler {
    * @returns  width
    */
   get width(): number {
-    return this.scaleX.range()[1];
+    return this.scaleX.range()[1] ?? 0;
   }
 
   /**
@@ -74,7 +73,7 @@ export class ZoomPanHandler {
    * @returns  height
    */
   get height(): number {
-    return this.scaleY.range()[1];
+    return this.scaleY.range()[1] ?? 0;
   }
 
   /**
@@ -111,8 +110,8 @@ export class ZoomPanHandler {
    * @returns  ratio
    */
   get xRatio(): number {
-    const domain: number[] = this.scaleX.domain();
-    const ratio: number = Math.abs(this.width / (domain[1] - domain[0]));
+    const domain = this.scaleX.domain() as [number, number];
+    const ratio = Math.abs(this.width / (domain[1] - domain[0]));
     return ratio;
   }
 
@@ -121,8 +120,8 @@ export class ZoomPanHandler {
    * @returns  ratio
    */
   get yRatio(): number {
-    const domain: number[] = this.scaleY.domain();
-    const ratio: number = Math.abs(this.height / (domain[1] - domain[0]));
+    const domain = this.scaleY.domain() as [number, number];
+    const ratio = Math.abs(this.height / (domain[1] - domain[0]));
     return ratio;
   }
 
@@ -237,8 +236,7 @@ export class ZoomPanHandler {
    * Initialized handler
    */
   init(): void {
-    this.zoom = zoom().scaleExtent([this.options.minZoomLevel, this.options.maxZoomLevel]).on('zoom', this.onZoom);
-
+    this.zoom = zoom<HTMLElement, unknown>().scaleExtent([this.options.minZoomLevel, this.options.maxZoomLevel]).on('zoom', this.onZoom);
     this.container.call(this.zoom);
   }
 
@@ -292,19 +290,20 @@ export class ZoomPanHandler {
   setViewport(cx?: number, cy?: number, displ?: number, duration?: number): void {
     const { zoom, container, calculateTransform, scaleX, scaleY, isXInverted } = this;
 
-    if (isNaN(cx) || isNaN(displ)) {
-      const xd: number[] = scaleX.domain();
+    if (cx == null || displ == null || isNaN(cx) || isNaN(displ)) {
+      const xd = scaleX.domain() as [number, number];
       const dspan: number = xd[1] - xd[0];
-      if (isNaN(cx)) {
+
+      if (cx == null || isNaN(cx)) {
         cx = xd[0] + dspan / 2 || 0;
       }
-      if (isNaN(displ)) {
+      if (displ == null || isNaN(displ)) {
         displ = Math.abs(dspan) || 1;
       }
     }
 
-    if (isNaN(cy)) {
-      const yd: number[] = scaleY.domain();
+    if (cy == null || isNaN(cy)) {
+      const yd = scaleY.domain() as [number, number];
       cy = yd[0] + (yd[1] - yd[0]) / 2 || 0;
     }
 
@@ -315,7 +314,7 @@ export class ZoomPanHandler {
 
     const t: ZoomTransform = calculateTransform(dx0, dx1, cy);
 
-    if (Number.isFinite(duration) && duration > 0) {
+    if (Number.isFinite(duration) && duration != null && duration > 0) {
       zoom.transform(container.transition().duration(duration), t);
     } else {
       zoom.transform(container, t);
@@ -346,19 +345,25 @@ export class ZoomPanHandler {
    * Adjust zoom due to changes in size of target
    * @param  force - force update even if size did not change
    */
-  adjustToSize(width?: number | boolean, height?: number, force: boolean = false): void {
+  adjustToSize(): void;
+  adjustToSize(autoAdjust: boolean): void;
+  adjustToSize(width: number, height: number, force: boolean): void;
+  adjustToSize(widthOrAutoAdjust?: unknown, height?: number, force: boolean = false): void {
     const { width: oldWidth, height: oldHeight, scaleX, scaleY, recalculateZoomTransform } = this;
 
     let w = 0;
     let h = 0;
 
-    if (typeof width === 'undefined' || typeof width === 'boolean') {
-      const { width: containerWidth, height: containerHeight } = this.container.node().getBoundingClientRect();
-      w = containerWidth;
-      h = containerHeight;
-    } else {
-      w = width;
+    if (typeof widthOrAutoAdjust === 'number' && typeof height === 'number') {
       h = height;
+      w = widthOrAutoAdjust;
+    } else {
+      const containerEl = this.container.node();
+      if (containerEl) {
+        const { width: containerWidth, height: containerHeight } = containerEl.getBoundingClientRect();
+        w = containerWidth;
+        h = containerHeight;
+      }
     }
 
     const newWidth: number = Math.max(1, w);
@@ -386,15 +391,15 @@ export class ZoomPanHandler {
   calculateTransform(dx0: number, dx1: number, dy: number): ZoomTransform {
     const { scaleX, xSpan, xBounds, yBounds, zFactor, viewportRatio: ratio, isXInverted, isYInverted } = this;
 
-    const [rx1, rx2] = scaleX.range();
-    const displ: number = Math.abs(dx1 - dx0);
-    const k: number = xSpan / displ;
-    const unitsPerPixels: number = displ / (rx2 - rx1);
+    const [rx1, rx2] = scaleX.range() as [number, number];
+    const displ = Math.abs(dx1 - dx0);
+    const k = xSpan / displ;
+    const unitsPerPixels = displ / (rx2 - rx1);
 
-    const dy0: number = dy - (isYInverted ? -displ : displ) / zFactor / ratio / 2;
+    const dy0 = dy - (isYInverted ? -displ : displ) / zFactor / ratio / 2;
 
-    const tx: number = (xBounds[0] - dx0) / (isXInverted ? -unitsPerPixels : unitsPerPixels);
-    const ty: number = (yBounds[0] - dy0) / ((isYInverted ? -unitsPerPixels : unitsPerPixels) / zFactor);
+    const tx = (xBounds[0] - dx0) / (isXInverted ? -unitsPerPixels : unitsPerPixels);
+    const ty = (yBounds[0] - dy0) / ((isYInverted ? -unitsPerPixels : unitsPerPixels) / zFactor);
 
     return zoomIdentity.translate(tx, ty).scale(k);
   }
@@ -405,8 +410,8 @@ export class ZoomPanHandler {
   recalculateZoomTransform(): void {
     const { scaleX, scaleY, container, calculateTransform, updateTranslateExtent } = this;
 
-    const [dx0, dx1] = scaleX.domain();
-    const [dy0, dy1] = scaleY.domain();
+    const [dx0, dx1] = scaleX.domain() as [number, number];
+    const [dy0, dy1] = scaleY.domain() as [number, number];
 
     const dy: number = dy0 + (dy1 - dy0) / 2;
 

--- a/src/control/ZoomPanHandler.ts
+++ b/src/control/ZoomPanHandler.ts
@@ -22,8 +22,8 @@ export class ZoomPanHandler {
   translateBoundsY: [number, number] = [0, 1];
   scaleX: ScaleLinear<number, number>;
   scaleY: ScaleLinear<number, number>;
-  _zFactor: number = 1;
-  _enableTranslateExtent: boolean = false;
+  _zFactor = 1;
+  _enableTranslateExtent = false;
   currentTransform: ZoomTransform | undefined;
 
   /**
@@ -182,10 +182,10 @@ export class ZoomPanHandler {
   updateTranslateExtent(): void {
     const { width, xSpan, zFactor, enableTranslateExtent, translateBoundsX, translateBoundsY } = this;
 
-    let x1: number = -Infinity;
-    let y1: number = -Infinity;
-    let x2: number = +Infinity;
-    let y2: number = +Infinity;
+    let x1 = -Infinity;
+    let y1 = -Infinity;
+    let x2 = +Infinity;
+    let y2 = +Infinity;
 
     if (enableTranslateExtent) {
       const ppu: number = width / xSpan;
@@ -348,7 +348,7 @@ export class ZoomPanHandler {
   adjustToSize(): void;
   adjustToSize(autoAdjust: boolean): void;
   adjustToSize(width: number, height: number, force: boolean): void;
-  adjustToSize(widthOrAutoAdjust?: unknown, height?: number, force: boolean = false): void {
+  adjustToSize(widthOrAutoAdjust?: unknown, height?: number, force = false): void {
     const { width: oldWidth, height: oldHeight, scaleX, scaleY, recalculateZoomTransform } = this;
 
     let w = 0;

--- a/src/control/ZoomPanHandler.ts
+++ b/src/control/ZoomPanHandler.ts
@@ -314,7 +314,7 @@ export class ZoomPanHandler {
 
     const t: ZoomTransform = calculateTransform(dx0, dx1, cy);
 
-    if (Number.isFinite(duration) && duration != null && duration > 0) {
+    if (duration != null && Number.isFinite(duration) && duration > 0) {
       zoom.transform(container.transition().duration(duration), t);
     } else {
       zoom.transform(container, t);

--- a/src/control/interfaces.ts
+++ b/src/control/interfaces.ts
@@ -18,8 +18,8 @@ export interface ControllerOptions {
 }
 
 interface OverlayEvent<T> {
-  target?: Element;
-  source: Element;
+  target: Element | undefined;
+  source: Element | undefined;
   caller: T;
 }
 

--- a/src/control/interfaces.ts
+++ b/src/control/interfaces.ts
@@ -33,7 +33,7 @@ export interface OverlayMouseMoveEvent<T> extends OverlayEvent<T> {
   y: number;
 }
 
-export interface OverlayMouseExitEvent<T> extends OverlayEvent<T> {}
+export type OverlayMouseExitEvent<T> = OverlayEvent<T>;
 
 export interface OverlayCallbacks<T> {
   onMouseMove?(event: OverlayMouseMoveEvent<T>): void;

--- a/src/datautils/colortable.ts
+++ b/src/datautils/colortable.ts
@@ -1,13 +1,13 @@
 import { scaleLinear } from 'd3-scale';
 import { color } from 'd3-color';
 
-export function createColorTable(colorMap: string[], size: number): number[][] {
+export function createColorTable(colorMap: string[], size: number): [number, number, number][] {
   const colorDomain = colorMap.map((_v, i) => (i * size) / colorMap.length);
   const colorScale = scaleLinear<string>().domain(colorDomain).range(colorMap);
 
-  const table = Array.from(new Array(size).keys()).map((i) => {
-    const rgb = color(colorScale(i)).rgb();
-    return [rgb.r, rgb.g, rgb.b];
+  const table = Array.from(new Array(size).keys()).map<[number, number, number]>((i) => {
+    const rgb = color(colorScale(i))?.rgb();
+    return rgb != null ? [rgb.r, rgb.g, rgb.b] : [0, 0, 0];
   });
 
   return table;

--- a/src/datautils/findsample.ts
+++ b/src/datautils/findsample.ts
@@ -47,15 +47,16 @@ export function findIndexOfSample(data: number[][], pos: number): number {
   return index;
 }
 
-export function findSampleAtPos(data: number[][], pos: number, topLimit: number = null, bottomLimit: number = null): number {
-  let y: number = null;
+export function findSampleAtPos(data: number[][], pos: number, topLimit = 0, bottomLimit = 0): number {
+  let y = 0;
   const index = findIndexOfSample(data, pos);
   if (index !== -1) {
-    const v1 = data[index][1];
-    const v2 = data[index + 1][1];
-    if (v2 && v2) {
-      const x1 = data[index][0];
-      const x2 = data[index + 1][0];
+    const v1 = data[index]?.[1];
+    const v2 = data[index + 1]?.[1];
+
+    if (v1 && v2) {
+      const x1 = data[index]?.[0] ?? 0;
+      const x2 = data[index + 1]?.[0] ?? 0;
       const span = x2 - x1;
       const d = pos - x1;
       const f = d / span;

--- a/src/datautils/picks.ts
+++ b/src/datautils/picks.ts
@@ -103,7 +103,7 @@ function getFilteredExitPicks(formationPicks: PairedPickAndUnit[]): Annotation[]
 
 export const getPicksData = (picksData: { unitPicks: PairedPickAndUnit[]; nonUnitPicks: PickWithId[] }): Annotation[] =>
   [...getReferencePicks(picksData.nonUnitPicks), ...getEntryPicks(picksData.unitPicks), ...getFilteredExitPicks(picksData.unitPicks)].sort(
-    (a, b) => a.md - b.md,
+    (a, b) => a.md! - b.md!,
   );
 
 /**
@@ -142,7 +142,7 @@ function findGaps(from: number, to: number, arr: { from: number; to: number; itm
   let d = from;
   let i = 0;
   while (d < to && i < arr.length) {
-    const itm = arr[i];
+    const itm = arr[i]!;
     if (itm.from > d) {
       gaps.push([d, Math.min(itm.from, to)]);
     }
@@ -171,13 +171,13 @@ function joinPicksAndStratColumn(picks: Pick[], stratColumn: Unit[]): { joined: 
   const nonUnitPicks: PickWithId[] = [];
   const joined: PickAndUnit[] = [];
   picks.forEach((p: Pick) => {
-    const matches = transformed.filter((u: UnitDto) => p.pickIdentifier.search(new RegExp(`(${u.topSurface}|${u.baseSurface})`, 'i')) !== -1);
+    const matches = transformed.filter((u: UnitDto) => p.pickIdentifier?.search(new RegExp(`(${u.topSurface}|${u.baseSurface})`, 'i')) !== -1);
     if (matches.length > 0) {
       matches.forEach((u: UnitDto) =>
         joined.push({
           md: p.md,
           tvd: p.tvd,
-          identifier: p.pickIdentifier,
+          identifier: p.pickIdentifier!,
           confidence: p.confidence,
           mdUnit: p.mdUnit,
           depthReferencePoint: p.depthReferencePoint,
@@ -185,7 +185,7 @@ function joinPicksAndStratColumn(picks: Pick[], stratColumn: Unit[]): { joined: 
         }),
       );
     } else {
-      nonUnitPicks.push({ identifier: p.pickIdentifier, ...p });
+      nonUnitPicks.push({ identifier: p.pickIdentifier!, ...p });
     }
   });
 
@@ -206,7 +206,7 @@ function pairJoinedPicks(joined: PickAndUnit[]): PairedPickAndUnit[] {
     .sort((a: PickAndUnit, b: PickAndUnit) => a.unitName.localeCompare(b.unitName) || a.md - b.md || a.ageTop - b.ageTop);
 
   while (sorted.length > 0) {
-    current = sorted.shift();
+    current = sorted.shift()!;
     const name = current.identifier;
     let pairWithName: string;
 
@@ -222,8 +222,8 @@ function pairJoinedPicks(joined: PickAndUnit[]): PairedPickAndUnit[] {
       continue;
     }
 
-    let top: PickAndUnit;
-    let base: PickAndUnit;
+    let top: PickAndUnit | undefined;
+    let base: PickAndUnit | undefined;
 
     const pairWith = sorted.find((p: PickAndUnit) => p.identifier === pairWithName);
     if (!pairWith) {
@@ -233,7 +233,7 @@ function pairJoinedPicks(joined: PickAndUnit[]): PairedPickAndUnit[] {
         base = joined
           .filter((d: PickAndUnit) => d.level)
           .sort((a: PickAndUnit, b: PickAndUnit) => a.md - b.md)
-          .find((p: PickAndUnit) => p.md > top.md);
+          .find((p: PickAndUnit) => p.md > top!.md);
         if (base) {
           console.warn(`Using ${base.identifier} as base for ${name}`);
         } else {
@@ -245,7 +245,7 @@ function pairJoinedPicks(joined: PickAndUnit[]): PairedPickAndUnit[] {
         top = joined
           .filter((d: PickAndUnit) => d.level)
           .sort((a: PickAndUnit, b: PickAndUnit) => b.md - a.md)
-          .find((p: PickAndUnit) => p.md < base.md);
+          .find((p: PickAndUnit) => p.md < base!.md);
         if (top) {
           console.warn(`Using ${top.identifier} as top for ${name}`);
         } else {
@@ -303,10 +303,10 @@ export function transformFormationData(picks: Pick[], stratColumn: Unit[]): { un
   // given presedence over lower levels for overlapping picks.
   const unitPicks = [];
   while (itemstack.length > 0) {
-    const first = itemstack.pop();
+    const first = itemstack.pop()!;
     const group: PairedPickAndUnit[] = [];
-    while (itemstack.length > 0 && itemstack[itemstack.length - 1].level > first.level) {
-      group.push(itemstack.pop());
+    while (itemstack.length > 0 && itemstack[itemstack.length - 1]?.level! > first.level) {
+      group.push(itemstack.pop()!);
     }
     group.reverse();
     group.push(first);

--- a/src/datautils/seismicimage.ts
+++ b/src/datautils/seismicimage.ts
@@ -44,11 +44,11 @@ export function getSeismicInfo(data: { datapoints: number[][]; yAxisValues: numb
   if (!(data && data.datapoints)) {
     return null;
   }
-  const minX = trajectory.reduce((acc: number, val: number[]) => Math.min(acc, val[0]), 0);
-  const maxX = trajectory.reduce((acc: number, val: number[]) => Math.max(acc, val[0]), 0);
+  const minX = trajectory.reduce((acc: number, val: number[]) => Math.min(acc, val[0]!), 0);
+  const maxX = trajectory.reduce((acc: number, val: number[]) => Math.max(acc, val[0]!), 0);
 
-  const minTvdMsl = data.yAxisValues && data.yAxisValues[0];
-  const maxTvdMsl = data.yAxisValues && data.yAxisValues[data.yAxisValues.length - 1];
+  const minTvdMsl = data.yAxisValues && data.yAxisValues[0]!;
+  const maxTvdMsl = data.yAxisValues && data.yAxisValues[data.yAxisValues.length - 1]!;
 
   // Find value domain
   const dp = data.datapoints || [];
@@ -117,8 +117,7 @@ export async function generateSeismicSliceImage(
     difference: dmax - dmin,
   };
 
-  const length = trajectory[0][0] - trajectory[trajectory.length - 1][0];
-  // eslint-disable-next-line no-magic-numbers
+  const length = trajectory[0]?.[0]! - trajectory[trajectory.length - 1]?.[0]!;
   const width = Math.abs(Math.floor(length / 5));
   const height = data.yAxisValues.length;
 
@@ -132,7 +131,7 @@ export async function generateSeismicSliceImage(
   let offset = 0;
   const colorFactor = (colorTableSize - 1) / domain.difference;
 
-  let pos = options?.isLeftToRight ? trajectory[0][0] : trajectory[trajectory.length - 1][0];
+  let pos = options?.isLeftToRight ? trajectory[0]?.[0]! : trajectory[trajectory.length - 1]?.[0]!;
 
   const step = (length / width) * (options?.isLeftToRight ? -1 : 1);
 
@@ -147,15 +146,15 @@ export async function generateSeismicSliceImage(
   for (let x = 0; x < width; x++) {
     offset = x * 4;
     const index = findIndexOfSample(trajectory, pos);
-    const x1 = trajectory[index][0];
-    const x2 = trajectory[index + 1][0];
+    const x1 = trajectory[index]?.[0]!;
+    const x2 = trajectory[index + 1]?.[0]!;
     const span = x2 - x1;
     const dx = pos - x1;
     const ratio = dx / span;
 
     for (let y = 0; y < height; y++) {
-      val1 = dp[y][index];
-      val2 = dp[y][index + 1];
+      val1 = dp[y]?.[index]!;
+      val2 = dp[y]?.[index + 1]!;
       if (val1 == null || val2 == null) {
         col = black;
         opacity = 0;
@@ -163,11 +162,11 @@ export async function generateSeismicSliceImage(
         val = val1 * (1 - ratio) + val2 * ratio;
         i = (val - domain.min) * colorFactor;
         i = clamp(~~i, 0, colorTableSize - 1);
-        col = colorTable[i];
+        col = colorTable[i]!;
         opacity = 255;
       }
 
-      d.set([col[0], col[1], col[2], opacity], offset);
+      d.set([col[0]!, col[1]!, col[2]!, opacity], offset);
 
       offset += width * 4;
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -15,7 +15,7 @@ export interface OnMountEvent extends LayerEvent {
   height?: number;
 }
 
-export interface OnUnmountEvent extends LayerEvent {}
+export type OnUnmountEvent = LayerEvent;
 
 export interface OnResizeEvent extends LayerEvent {
   width: number;

--- a/src/layers/CalloutCanvasLayer.ts
+++ b/src/layers/CalloutCanvasLayer.ts
@@ -136,15 +136,7 @@ export class CalloutCanvasLayer<T extends Annotation[]> extends CanvasLayer<T> {
     this.renderText(label, x, y, fontSize, color);
   };
 
-  private renderText(
-    title: string,
-    x: number,
-    y: number,
-    fontSize: number,
-    color: string,
-    font: string = 'arial',
-    fontStyle: string = 'normal',
-  ): void {
+  private renderText(title: string, x: number, y: number, fontSize: number, color: string, font = 'arial', fontStyle = 'normal'): void {
     const { ctx } = this;
     if (ctx != null) {
       ctx.font = `${fontStyle} ${fontSize}px ${font}`;
@@ -153,7 +145,7 @@ export class CalloutCanvasLayer<T extends Annotation[]> extends CanvasLayer<T> {
     }
   }
 
-  private renderPoint(x: number, y: number, radius: number = 3): void {
+  private renderPoint(x: number, y: number, radius = 3): void {
     const { ctx } = this;
 
     if (ctx != null) {
@@ -175,7 +167,7 @@ export class CalloutCanvasLayer<T extends Annotation[]> extends CanvasLayer<T> {
     this.renderLine(x, y, width, dotX, dotY, color, placeLeft);
   }
 
-  private renderLine = (x: number, y: number, width: number, dotX: number, dotY: number, color: string, placeLeft: boolean = true): void => {
+  private renderLine = (x: number, y: number, width: number, dotX: number, dotY: number, color: string, placeLeft = true): void => {
     const { ctx } = this;
     const textX = placeLeft ? x : x + width;
     const inverseTextX = placeLeft ? x + width : x;
@@ -233,7 +225,7 @@ export class CalloutCanvasLayer<T extends Annotation[]> extends CanvasLayer<T> {
     yScale: ScaleLinear<number, number>,
     _scale: number,
     fontSize: number,
-    offset: number = 20,
+    offset = 20,
   ): Callout[] {
     if (annotations.length === 0) {
       return [];

--- a/src/layers/CustomDisplayObjects/ComplexRopeGeometry.ts
+++ b/src/layers/CustomDisplayObjects/ComplexRopeGeometry.ts
@@ -28,7 +28,7 @@ export class ComplexRopeGeometry extends MeshGeometry {
    * @readonly
    */
   get width(): number {
-    return max(this.segments, (segment) => segment.diameter);
+    return max(this.segments, (segment) => segment.diameter)!;
   }
 
   /** Refreshes Rope indices and uvs */
@@ -66,7 +66,7 @@ export class ComplexRopeGeometry extends MeshGeometry {
     uvs[3] = 1;
 
     const segmentCount = segments.length;
-    const maxDiameter = max(segments, (segment) => segment.diameter);
+    const maxDiameter = max(segments, (segment) => segment.diameter)!;
 
     let amount = 0;
     let uvIndex = 0;
@@ -74,21 +74,21 @@ export class ComplexRopeGeometry extends MeshGeometry {
     let indexCount = 0;
 
     for (let i = 0; i < segmentCount; i++) {
-      let prev = segments[i].points[0];
+      let prev = segments[i]?.points[0]!;
       const textureWidth = maxDiameter;
-      const radius = segments[i].diameter / maxDiameter / 2;
+      const radius = segments[i]?.diameter! / maxDiameter / 2;
 
-      const total = segments[i].points.length; // - 1;
+      const total = segments[i]?.points.length!; // - 1;
 
       for (let j = 0; j < total; j++) {
         // time to do some smart drawing!
 
         // calculate pixel distance from previous point
-        const dx = prev.x - segments[i].points[j].x;
-        const dy = prev.y - segments[i].points[j].y;
+        const dx = prev.x - segments[i]?.points[j]?.x!;
+        const dy = prev.y - segments[i]?.points[j]?.y!;
         const distance = Math.sqrt(dx * dx + dy * dy);
 
-        prev = segments[i].points[j];
+        prev = segments[i]?.points[j]!;
         amount += distance / textureWidth;
 
         uvs[uvIndex] = amount;
@@ -131,20 +131,20 @@ export class ComplexRopeGeometry extends MeshGeometry {
     const segmentCount = segments.length;
     let lastIndex = 0;
     for (let i = 0; i < segmentCount; i++) {
-      let lastPoint = segments[i].points[0];
+      let lastPoint = segments[i]?.points[0]!;
       let nextPoint;
       let perpX = 0;
       let perpY = 0;
 
-      const vertices = this.buffers[0].data;
-      const total = segments[i].points.length;
+      const vertices = this.buffers[0]?.data;
+      const total = segments[i]?.points.length!;
       let index = 0;
       for (let j = 0; j < total; j++) {
-        const point = segments[i].points[j];
+        const point = segments[i]?.points[j]!;
         index = lastIndex + j * 4;
 
-        if (j < segments[i].points.length - 1) {
-          nextPoint = segments[i].points[j + 1];
+        if (j < segments[i]?.points.length! - 1) {
+          nextPoint = segments[i]?.points[j + 1]!;
         } else {
           nextPoint = point;
         }
@@ -153,7 +153,7 @@ export class ComplexRopeGeometry extends MeshGeometry {
         perpX = nextPoint.y - lastPoint.y;
 
         const perpLength = Math.sqrt(perpX * perpX + perpY * perpY);
-        const num = segments[i].diameter / 2;
+        const num = segments[i]?.diameter! / 2;
 
         perpX /= perpLength;
         perpY /= perpLength;
@@ -161,16 +161,19 @@ export class ComplexRopeGeometry extends MeshGeometry {
         perpX *= num;
         perpY *= num;
 
-        vertices[index] = point.x + perpX;
-        vertices[index + 1] = point.y + perpY;
-        vertices[index + 2] = point.x - perpX;
-        vertices[index + 3] = point.y - perpY;
+        if (vertices != null) {
+          vertices[index] = point.x + perpX;
+          vertices[index + 1] = point.y + perpY;
+          vertices[index + 2] = point.x - perpX;
+          vertices[index + 3] = point.y - perpY;
+        }
+
         lastPoint = point;
       }
       lastIndex = index + 4;
     }
 
-    this.buffers[0].update();
+    this.buffers[0]?.update();
   }
 
   public update(): void {

--- a/src/layers/CustomDisplayObjects/FixedWidthSimpleRopeGeometry.ts
+++ b/src/layers/CustomDisplayObjects/FixedWidthSimpleRopeGeometry.ts
@@ -8,7 +8,6 @@ export class FixedWidthSimpleRopeGeometry extends MeshGeometry {
    * @param {PIXI.Point[]} [points] - An array of PIXI.Point objects to construct this rope.
    */
   constructor(points: IPoint[], width = 200) {
-    // eslint-disable-next-line no-magic-numbers
     super(new Float32Array(points.length * 4), new Float32Array(points.length * 4), new Uint16Array((points.length - 1) * 6));
     /**
      * An array of points that determine the rope
@@ -66,17 +65,17 @@ export class FixedWidthSimpleRopeGeometry extends MeshGeometry {
     uvs[2] = 0;
     uvs[3] = 1;
     let amount = 0;
-    let prev = points[0];
+    let prev = points[0]!;
     const total = points.length; // - 1;
     for (let i = 0; i < total; i++) {
       // time to do some smart drawing!
       const index = i * 4;
 
       // calculate pixel distance from previous point
-      const dx = prev.x - points[i].x;
-      const dy = prev.y - points[i].y;
+      const dx = prev.x - points[i]?.x!;
+      const dy = prev.y - points[i]?.y!;
       const distance = Math.sqrt(dx * dx + dy * dy);
-      prev = points[i];
+      prev = points[i]!;
       amount += distance / this._width;
 
       uvs[index] = amount;
@@ -107,17 +106,17 @@ export class FixedWidthSimpleRopeGeometry extends MeshGeometry {
     if (points.length < 1) {
       return;
     }
-    let lastPoint = points[0];
+    let lastPoint = points[0]!;
     let nextPoint;
     let perpX = 0;
     let perpY = 0;
-    const vertices = this.buffers[0].data;
+    const vertices = this.buffers[0]?.data!;
     const total = points.length;
     for (let i = 0; i < total; i++) {
-      const point = points[i];
+      const point = points[i]!;
       const index = i * 4;
       if (i < points.length - 1) {
-        nextPoint = points[i + 1];
+        nextPoint = points[i + 1]!;
       } else {
         nextPoint = point;
       }
@@ -140,7 +139,7 @@ export class FixedWidthSimpleRopeGeometry extends MeshGeometry {
       vertices[index + 3] = point.y - perpY;
       lastPoint = point;
     }
-    this.buffers[0].update();
+    this.buffers[0]?.update();
   }
 
   public update(): void {

--- a/src/layers/CustomDisplayObjects/UniformTextureStretchRopeGeometry.ts
+++ b/src/layers/CustomDisplayObjects/UniformTextureStretchRopeGeometry.ts
@@ -55,14 +55,14 @@ export class UniformTextureStretchRopeGeometry extends MeshGeometry {
     const total = points.length; // - 1;
 
     let totalLength = 0;
-    let prevPoint = points[0];
+    let prevPoint = points[0]!;
 
     for (let i = 0; i < total; i++) {
-      const dx = prevPoint.x - points[i].x;
-      const dy = prevPoint.y - points[i].y;
+      const dx = prevPoint.x - points[i]?.x!;
+      const dy = prevPoint.y - points[i]?.y!;
       const distance = Math.sqrt(dx * dx + dy * dy);
 
-      prevPoint = points[i];
+      prevPoint = points[i]!;
       totalLength += distance;
     }
 
@@ -75,18 +75,18 @@ export class UniformTextureStretchRopeGeometry extends MeshGeometry {
     uvs[3] = 1;
 
     let amount = 0;
-    let prev = points[0];
+    let prev = points[0]!;
 
     for (let i = 0; i < total; i++) {
       // time to do some smart drawing!
       const index = i * 4;
 
       // calculate pixel distance from previous point
-      const dx = prev.x - points[i].x;
-      const dy = prev.y - points[i].y;
+      const dx = prev.x - points[i]?.x!;
+      const dy = prev.y - points[i]?.y!;
       const distance = Math.sqrt(dx * dx + dy * dy);
 
-      prev = points[i];
+      prev = points[i]!;
 
       // strech texture on distance/length instead of point/points.length to get a more correct strech
       amount += distance / totalLength;
@@ -127,20 +127,20 @@ export class UniformTextureStretchRopeGeometry extends MeshGeometry {
       return;
     }
 
-    let lastPoint = points[0];
+    let lastPoint = points[0]!;
     let nextPoint;
     let perpX = 0;
     let perpY = 0;
 
-    const vertices = this.buffers[0].data;
+    const vertices = this.buffers[0]?.data!;
     const total = points.length;
 
     for (let i = 0; i < total; i++) {
-      const point = points[i];
+      const point = points[i]!;
       const index = i * 4;
 
       if (i < points.length - 1) {
-        nextPoint = points[i + 1];
+        nextPoint = points[i + 1]!;
       } else {
         nextPoint = point;
       }
@@ -165,7 +165,7 @@ export class UniformTextureStretchRopeGeometry extends MeshGeometry {
       lastPoint = point;
     }
 
-    this.buffers[0].update();
+    this.buffers[0]?.update();
   }
 
   public update(): void {

--- a/src/layers/GeomodelCanvasLayer.ts
+++ b/src/layers/GeomodelCanvasLayer.ts
@@ -12,7 +12,7 @@ type SurfacePaths = {
 };
 
 export class GeomodelCanvasLayer<T extends SurfaceData> extends CanvasLayer<T> {
-  rescaleEvent: OnRescaleEvent;
+  rescaleEvent: OnRescaleEvent | undefined;
 
   surfaceAreasPaths: SurfacePaths[] = [];
 
@@ -69,65 +69,72 @@ export class GeomodelCanvasLayer<T extends SurfaceData> extends CanvasLayer<T> {
   }
 
   generateSurfaceAreasPaths(): void {
-    this.surfaceAreasPaths = this.data.areas.reduce((acc: SurfacePaths[], s: SurfaceArea) => {
-      const polygons = this.createPolygons(s.data);
-      const mapped: SurfacePaths[] = polygons.map((polygon: number[]) => ({
-        color: this.colorToCSSColor(s.color),
-        path: this.generatePolygonPath(polygon),
-      }));
-      acc.push(...mapped);
-      return acc;
-    }, []);
+    this.surfaceAreasPaths =
+      this.data?.areas.reduce((acc: SurfacePaths[], s: SurfaceArea) => {
+        const polygons = this.createPolygons(s.data);
+        const mapped: SurfacePaths[] = polygons.map((polygon: number[]) => ({
+          color: this.colorToCSSColor(s.color),
+          path: this.generatePolygonPath(polygon),
+        }));
+        acc.push(...mapped);
+        return acc;
+      }, []) ?? [];
   }
 
   generateSurfaceLinesPaths(): void {
-    this.surfaceLinesPaths = this.data.lines.reduce((acc: SurfacePaths[], l: SurfaceLine) => {
-      const lines = this.generateLinePaths(l);
-      const mapped: SurfacePaths[] = lines.map((path: Path2D) => ({ color: this.colorToCSSColor(l.color), path }));
-      acc.push(...mapped);
-      return acc;
-    }, []);
+    this.surfaceLinesPaths =
+      this.data?.lines.reduce((acc: SurfacePaths[], l: SurfaceLine) => {
+        const lines = this.generateLinePaths(l);
+        const mapped: SurfacePaths[] = lines.map((path: Path2D) => ({ color: this.colorToCSSColor(l.color), path }));
+        acc.push(...mapped);
+        return acc;
+      }, []) ?? [];
   }
 
   drawPolygonPath = (color: string, path: Path2D): void => {
     const { ctx } = this;
-    ctx.fillStyle = color;
-    ctx.fill(path);
+    if (ctx != null) {
+      ctx.fillStyle = color;
+      ctx.fill(path);
+    }
   };
 
   drawLinePath = (color: string, path: Path2D): void => {
     const { ctx } = this;
-    ctx.strokeStyle = color;
-    ctx.stroke(path);
+
+    if (ctx != null) {
+      ctx.strokeStyle = color;
+      ctx.stroke(path);
+    }
   };
 
   createPolygons = (data: number[][]): number[][] => {
     const polygons: number[][] = [];
-    let polygon: number[] = null;
+    let polygon: number[] = [];
 
     // Start generating polygons
     for (let i = 0; i < data.length; i++) {
       // Generate top of polygon as long as we have valid values
-      const topIsValid = !!data[i][1];
+      const topIsValid = !!data[i]?.[1];
       if (topIsValid) {
         if (polygon === null) {
           polygon = [];
         }
-        polygon.push(data[i][0], data[i][1]);
+        polygon.push(data[i]?.[0]!, data[i]?.[1]!);
       }
 
       const endIsReached = i === data.length - 1;
       if (!topIsValid || endIsReached) {
-        if (polygon) {
+        if (polygon.length > 0) {
           // Generate bottom of polygon
           for (let j: number = !topIsValid ? i - 1 : i; j >= 0; j--) {
-            if (!data[j][1]) {
+            if (!data[j]?.[1]) {
               break;
             }
-            polygon.push(data[j][0], data[j][2] || this.maxDepth);
+            polygon.push(data[j]?.[0]!, data[j]?.[2] || this.maxDepth);
           }
           polygons.push(polygon);
-          polygon = null;
+          polygon = [];
         }
       }
     }
@@ -138,9 +145,9 @@ export class GeomodelCanvasLayer<T extends SurfaceData> extends CanvasLayer<T> {
   generatePolygonPath = (polygon: number[]): Path2D => {
     const path = new Path2D();
 
-    path.moveTo(polygon[0], polygon[1]);
+    path.moveTo(polygon[0]!, polygon[1]!);
     for (let i = 2; i < polygon.length; i += 2) {
-      path.lineTo(polygon[i], polygon[i + 1]);
+      path.lineTo(polygon[i]!, polygon[i + 1]!);
     }
     path.closePath();
 
@@ -152,22 +159,22 @@ export class GeomodelCanvasLayer<T extends SurfaceData> extends CanvasLayer<T> {
     const { data: d } = s;
 
     let penDown = false;
-    let path = null;
+    let path: Path2D | undefined;
     for (let i = 0; i < d.length; i++) {
-      if (d[i][1]) {
-        if (penDown) {
-          path.lineTo(d[i][0], d[i][1]);
+      if (d[i]?.[1]) {
+        if (penDown && path) {
+          path.lineTo(d[i]?.[0]!, d[i]?.[1]!);
         } else {
           path = new Path2D();
-          path.moveTo(d[i][0], d[i][1]);
+          path.moveTo(d[i]?.[0]!, d[i]?.[1]!);
           penDown = true;
         }
-      } else if (penDown) {
+      } else if (penDown && path) {
         paths.push(path);
         penDown = false;
       }
     }
-    if (penDown) {
+    if (penDown && path) {
       paths.push(path);
     }
 

--- a/src/layers/GeomodelLabelsLayer.ts
+++ b/src/layers/GeomodelLabelsLayer.ts
@@ -361,7 +361,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     step: number,
     topLimit?: number,
     bottomLimit?: number,
-    alternativeSurfaceData: number[][] = null,
+    alternativeSurfaceData?: number[][],
     surfaces: SurfaceArea[] | null = null,
     currentSurfaceIndex?: number,
   ): Vector2 | null {
@@ -388,12 +388,12 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
 
   getAlternativeYValueIfAvailable(
     x: number,
-    topLimit: number,
-    bottomLimit: number,
-    alternativeSurfaceData: number[][],
-    surfaces: SurfaceArea[] | null,
-    currentSurfaceIndex: number,
-  ): number {
+    topLimit?: number,
+    bottomLimit?: number,
+    alternativeSurfaceData?: number[][],
+    surfaces: SurfaceArea[] | null = null,
+    currentSurfaceIndex?: number,
+  ): number | null {
     if (!alternativeSurfaceData) {
       return null;
     }
@@ -454,7 +454,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     minReductionAngle: number = 0,
     maxReductionAngle: number = Math.PI / 4,
     angleReductionExponent: number = 4,
-    alternativeSurfaceBottomData: number[][] = null,
+    alternativeSurfaceBottomData: number[][],
     surfaces: SurfaceArea[] | null = null,
     currentSurfaceIndex: number,
   ): number {

--- a/src/layers/GeomodelLabelsLayer.ts
+++ b/src/layers/GeomodelLabelsLayer.ts
@@ -34,9 +34,9 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
   defaultFont: string = DEFAULT_FONT;
 
   rescaleEvent: OnRescaleEvent | undefined;
-  isLabelsOnLeftSide: boolean = true;
+  isLabelsOnLeftSide = true;
   maxFontSizeInWorldCoordinates: number = MAX_FONT_SIZE_IN_WORLD_COORDINATES;
-  isXFlipped: boolean = false;
+  isXFlipped = false;
   areasWithAvgTopDepth: SurfaceAreaWithAvgTopDepth[] = [];
 
   constructor(id?: string, options?: GeomodelLayerLabelsOptions<T>) {
@@ -451,9 +451,9 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     initalVector: Vector2 = Vector2.left,
     topLimit: number,
     bottomLimit: number,
-    minReductionAngle: number = 0,
+    minReductionAngle = 0,
     maxReductionAngle: number = Math.PI / 4,
-    angleReductionExponent: number = 4,
+    angleReductionExponent = 4,
     alternativeSurfaceBottomData: number[][],
     surfaces: SurfaceArea[] | null = null,
     currentSurfaceIndex: number,

--- a/src/layers/GeomodelLabelsLayer.ts
+++ b/src/layers/GeomodelLabelsLayer.ts
@@ -33,11 +33,11 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
   defaultTextColor: string = DEFAULT_TEXT_COLOR;
   defaultFont: string = DEFAULT_FONT;
 
-  rescaleEvent: OnRescaleEvent;
+  rescaleEvent: OnRescaleEvent | undefined;
   isLabelsOnLeftSide: boolean = true;
   maxFontSizeInWorldCoordinates: number = MAX_FONT_SIZE_IN_WORLD_COORDINATES;
   isXFlipped: boolean = false;
-  areasWithAvgTopDepth: SurfaceAreaWithAvgTopDepth[] = null;
+  areasWithAvgTopDepth: SurfaceAreaWithAvgTopDepth[] = [];
 
   constructor(id?: string, options?: GeomodelLayerLabelsOptions<T>) {
     super(id, options);
@@ -54,11 +54,11 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
 
   override setData(data: T): void {
     super.setData(data);
-    this.areasWithAvgTopDepth = null;
+    this.areasWithAvgTopDepth = [];
   }
 
   generateSurfacesWithAvgDepth(): void {
-    const { areas } = this.data;
+    const areas = this.data?.areas ?? [];
     this.areasWithAvgTopDepth = areas.reduce((acc: SurfaceAreaWithAvgTopDepth[], area: SurfaceArea) => {
       // Filter surfaces without label
       if (!area.label) {
@@ -118,7 +118,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
         return;
       }
 
-      if (!this.areasWithAvgTopDepth) {
+      if (this.areasWithAvgTopDepth.length <= 0) {
         this.generateSurfacesWithAvgDepth();
       }
 
@@ -147,13 +147,15 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
   }
 
   drawLineLabels(): void {
-    this.data.lines.filter((surfaceLine: SurfaceLine) => surfaceLine.label).forEach((surfaceLine: SurfaceLine) => this.drawLineLabel(surfaceLine));
+    this.data?.lines.filter((surfaceLine: SurfaceLine) => surfaceLine.label).forEach((surfaceLine: SurfaceLine) => this.drawLineLabel(surfaceLine));
   }
 
   drawAreaLabel = (surfaceArea: SurfaceArea, nextSurfaceArea: SurfaceArea | null, surfaces: SurfaceArea[], i: number): void => {
     const { data } = surfaceArea;
     const { ctx, maxFontSizeInWorldCoordinates, isXFlipped } = this;
-    const { xScale, yScale, xRatio, yRatio, zFactor } = this.rescaleEvent;
+    const { xScale, yScale, xRatio, yRatio, zFactor } = this.rescaleEvent!;
+    if (ctx == null) return;
+
     let isLabelsOnLeftSide = this.checkDrawLabelsOnLeftSide();
     const margins = (this.options.margins || this.defaultMargins) * (isXFlipped ? -1 : 1);
     const marginsInWorldCoords = margins / xRatio;
@@ -168,14 +170,14 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       }
     }
 
-    const leftEdge = xScale.invert(xScale.range()[0]) + marginsInWorldCoords;
-    const rightEdge = xScale.invert(xScale.range()[1]) - marginsInWorldCoords;
-    const [surfaceAreaLeftEdge, surfaceAreaRightEdge] = this.getSurfacesAreaEdges();
+    const leftEdge = xScale.invert(xScale.range()[0]!) + marginsInWorldCoords;
+    const rightEdge = xScale.invert(xScale.range()[1]!) - marginsInWorldCoords;
+    const [surfaceAreaLeftEdge, surfaceAreaRightEdge] = this.getSurfacesAreaEdges() as [number, number];
 
     // Get label metrics
     ctx.save();
     ctx.font = `${fontSizeInWorldCoords * yRatio}px ${this.options.font || this.defaultFont}`;
-    let labelMetrics = ctx.measureText(surfaceArea.label);
+    let labelMetrics = ctx.measureText(surfaceArea.label ?? '');
     let labelLengthInWorldCoords = labelMetrics.width / xRatio;
 
     // Check if label will fit horizontally
@@ -200,8 +202,8 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       startPos = isXFlipped ? Math.max(surfaceAreaRightEdge, rightEdge) : Math.min(surfaceAreaRightEdge, rightEdge);
     }
 
-    const topEdge = yScale.invert(yScale.range()[0]);
-    const bottomEdge = yScale.invert(yScale.range()[1]);
+    const topEdge = yScale.invert(yScale.range()[0]!);
+    const bottomEdge = yScale.invert(yScale.range()[1]!);
 
     // Calculate where to sample points
     const dirSteps = 5;
@@ -211,14 +213,14 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     const dirStep = (labelLengthInWorldCoords / dirSteps) * (isLabelsOnLeftSide ? 1 : -1) * (isXFlipped ? -1 : 1);
 
     // Sample points from top and calculate position
-    const topData = data.map((d) => [d[0], d[1]]);
+    const topData = data.map((d) => [d[0]!, d[1]!]);
     const topPos = this.calcPos(topData, startPos, posSteps, posStep, topEdge, bottomEdge);
     if (!topPos) {
       return;
     }
 
     // Sample points from bottom and calculate position
-    const bottomData = data.map((d) => [d[0], d[2]]);
+    const bottomData = data.map((d) => [d[0]!, d[2]!]);
     let bottomPos = this.calcPos(
       bottomData,
       startPos,
@@ -226,7 +228,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       posStep,
       topEdge,
       bottomEdge,
-      nextSurfaceArea ? nextSurfaceArea.data.map((d) => [d[0], d[1]]) : null,
+      nextSurfaceArea?.data.map((d) => [d[0]!, d[1]!]) ?? [],
       surfaces,
       i,
     );
@@ -244,7 +246,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       // Use reduced fontsize
       fontSizeInWorldCoords = thickness;
       ctx.font = `${fontSizeInWorldCoords * yRatio}px ${this.options.font || this.defaultFont}`;
-      labelMetrics = ctx.measureText(surfaceArea.label);
+      labelMetrics = ctx.measureText(surfaceArea.label ?? '');
       labelLengthInWorldCoords = labelMetrics.width / xRatio;
     }
     // Sample points from top and bottom and calculate direction vector
@@ -261,7 +263,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       0,
       Math.PI / 4,
       4,
-      nextSurfaceArea ? nextSurfaceArea.data.map((d) => [d[0], d[1]]) : null,
+      nextSurfaceArea?.data.map((d) => [d[0]!, d[1]!]) ?? [],
       surfaces,
       i,
     );
@@ -271,20 +273,24 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     const textX = startPos;
     const textY = (topPos.y + bottomPos.y) / 2;
     const textAngle = isXFlipped ? -scaledAngle : scaledAngle;
-    ctx.textAlign = isLabelsOnLeftSide ? 'left' : 'right';
-    ctx.translate(xScale(textX), yScale(textY));
-    ctx.rotate(textAngle);
-    ctx.fillStyle = this.options.textColor || this.defaultTextColor;
-    ctx.font = `${fontSizeInWorldCoords * yRatio}px ${this.options.font || this.defaultFont}`;
-    ctx.textBaseline = 'middle';
-    ctx.fillText(surfaceArea.label, 0, 0);
 
-    ctx.restore();
+    if (ctx) {
+      ctx.textAlign = isLabelsOnLeftSide ? 'left' : 'right';
+      ctx.translate(xScale(textX), yScale(textY));
+      ctx.rotate(textAngle);
+      ctx.fillStyle = this.options.textColor || this.defaultTextColor;
+      ctx.font = `${fontSizeInWorldCoords * yRatio}px ${this.options.font || this.defaultFont}`;
+      ctx.textBaseline = 'middle';
+      ctx.fillText(surfaceArea.label ?? '', 0, 0);
+
+      ctx.restore();
+    }
   };
 
   drawLineLabel = (s: SurfaceLine): void => {
     const { ctx, isXFlipped } = this;
-    const { xScale, yScale, xRatio, yRatio, zFactor } = this.rescaleEvent;
+    const { xScale, yScale, xRatio, yRatio, zFactor } = this.rescaleEvent!;
+    if (ctx == null) return;
     const isLabelsOnLeftSide = this.checkDrawLabelsOnLeftSide();
     const marginsInWorldCoords = this.getMarginsInWorldCoordinates();
     const maxFontSize = this.options.maxFontSize || this.defaultMaxFontSize;
@@ -296,9 +302,9 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     const labelMetrics = ctx.measureText(s.label);
     const labelLengthInWorldCoords = labelMetrics.width / xRatio;
 
-    const leftEdge = xScale.invert(xScale.range()[0]) + marginsInWorldCoords;
-    const rightEdge = xScale.invert(xScale.range()[1]) - marginsInWorldCoords;
-    const [surfaceAreaLeftEdge, surfaceAreaRightEdge] = this.getSurfacesAreaEdges();
+    const leftEdge = xScale.invert(xScale.range()[0]!) + marginsInWorldCoords;
+    const rightEdge = xScale.invert(xScale.range()[1]!) - marginsInWorldCoords;
+    const [surfaceAreaLeftEdge, surfaceAreaRightEdge] = this.getSurfacesAreaEdges() as [number, number];
 
     // Find edge where to draw
     let startPos: number;
@@ -326,14 +332,16 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     const textDir = Vector2.angleRight(dir) - (isLabelsOnLeftSide ? Math.PI : 0);
 
     // Draw label
-    ctx.textAlign = isLabelsOnLeftSide ? 'right' : 'left';
-    ctx.translate(xScale(textX), yScale(textY));
-    ctx.rotate(textDir);
-    ctx.fillStyle = this.colorToCSSColor(s.color);
-    ctx.textBaseline = 'middle';
-    ctx.fillText(s.label, 0, 0);
+    if (ctx) {
+      ctx.textAlign = isLabelsOnLeftSide ? 'right' : 'left';
+      ctx.translate(xScale(textX), yScale(textY));
+      ctx.rotate(textDir);
+      ctx.fillStyle = this.colorToCSSColor(s.color);
+      ctx.textBaseline = 'middle';
+      ctx.fillText(s.label, 0, 0);
 
-    ctx.restore();
+      ctx.restore();
+    }
   };
 
   colorToCSSColor(color: number | string): string {
@@ -342,7 +350,6 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     }
 
     let hexString = color.toString(16);
-    // eslint-disable-next-line no-magic-numbers
     hexString = '000000'.substr(0, 6 - hexString.length) + hexString;
     return `#${hexString}`;
   }
@@ -352,12 +359,12 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     offset: number,
     count: number,
     step: number,
-    topLimit: number = null,
-    bottomLimit: number = null,
+    topLimit?: number,
+    bottomLimit?: number,
     alternativeSurfaceData: number[][] = null,
     surfaces: SurfaceArea[] | null = null,
-    currentSurfaceIndex: number = null,
-  ): Vector2 {
+    currentSurfaceIndex?: number,
+  ): Vector2 | null {
     const pos = Vector2.zero.mutable;
     let samples = 0;
     for (let i = 0; i < count; i++) {
@@ -397,12 +404,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       let si = currentSurfaceIndex + 1;
       while (altY == null && si < surfaces.length) {
         const altSurface = surfaces[si++];
-        altY = findSampleAtPos(
-          altSurface.data.map((d: number[]) => [d[0], d[1]]),
-          x,
-          topLimit,
-          bottomLimit,
-        );
+        altY = findSampleAtPos(altSurface?.data.map((d: number[]) => [d[0]!, d[1]!]) ?? [], x, topLimit, bottomLimit);
       }
     }
     return altY;
@@ -415,8 +417,8 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     step: number,
     zFactor: number,
     initalVector: Vector2 = Vector2.left,
-    topLimit: number = null,
-    bottomLimit: number = null,
+    topLimit?: number,
+    bottomLimit?: number,
   ): Vector2 {
     const dir = initalVector.mutable;
 
@@ -447,14 +449,14 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     count: number,
     step: number,
     initalVector: Vector2 = Vector2.left,
-    topLimit: number = null,
-    bottomLimit: number = null,
+    topLimit: number,
+    bottomLimit: number,
     minReductionAngle: number = 0,
     maxReductionAngle: number = Math.PI / 4,
     angleReductionExponent: number = 4,
     alternativeSurfaceBottomData: number[][] = null,
     surfaces: SurfaceArea[] | null = null,
-    currentSurfaceIndex: number = null,
+    currentSurfaceIndex: number,
   ): number {
     const angles: number[] = [];
     const tmpVec = Vector2.zero.mutable;
@@ -483,7 +485,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       } else {
         if (topY !== null) {
           tmpVec.set(x, (topY + usedBottomY) / 2);
-          tmpVec.sub(vecAtEnd);
+          tmpVec.sub(vecAtEnd!);
 
           angles.push(Vector2.angleRight(tmpVec));
         } else {
@@ -492,7 +494,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       }
     }
 
-    const refAngle = angles[0];
+    const refAngle = angles[0]!;
     const offsetAngles = angles.map((d: number) => d - refAngle);
     let factors = 0;
     const offsetSum = offsetAngles.reduce((acc: number, v: number) => {
@@ -506,50 +508,51 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
   }
 
   updateXFlipped(): void {
-    const { xBounds } = this.rescaleEvent;
+    const { xBounds } = this.rescaleEvent!;
     this.isXFlipped = xBounds[0] > xBounds[1];
   }
 
   getMarginsInWorldCoordinates(): number {
-    const { xRatio } = this.rescaleEvent;
+    const { xRatio } = this.rescaleEvent!;
     const margins = (this.options.margins || this.defaultMargins) * (this.isXFlipped ? -1 : 1);
     const marginsInWorldCoords = margins / xRatio;
     return marginsInWorldCoords;
   }
 
   getSurfacesAreaEdges(): number[] {
-    const endPoints = this.data.areas.reduce((acc, area) => {
-      const { data } = area;
-      const firstValidPoint = data.find((d: number[]) => d[1] != null);
-      if (firstValidPoint) {
-        acc.push(firstValidPoint[0]);
-      }
-      // TODO: Use findLast() when TypeScript stops complaining about it
-      for (let i = data.length - 1; i >= 0; i--) {
-        if (data[i][1] != null) {
-          acc.push(data[i][0]);
-          break;
-        }
-      }
-
-      return acc;
-    }, []);
-    endPoints.push(
-      ...this.data.lines.reduce((acc, line) => {
-        const { data } = line;
+    const endPoints =
+      this.data?.areas.reduce((acc, area) => {
+        const { data } = area;
         const firstValidPoint = data.find((d: number[]) => d[1] != null);
         if (firstValidPoint) {
-          acc.push(firstValidPoint[0]);
+          acc.push(firstValidPoint[0]!);
         }
         // TODO: Use findLast() when TypeScript stops complaining about it
         for (let i = data.length - 1; i >= 0; i--) {
-          if (data[i][1] != null) {
-            acc.push(data[i][0]);
+          if (data[i]?.[1] != null) {
+            acc.push(data[i]?.[0]!);
+            break;
+          }
+        }
+
+        return acc;
+      }, [] as number[]) ?? [];
+    endPoints.push(
+      ...(this.data?.lines.reduce((acc, line) => {
+        const { data } = line;
+        const firstValidPoint = data.find((d: number[]) => d[1] != null);
+        if (firstValidPoint) {
+          acc.push(firstValidPoint[0]!);
+        }
+        // TODO: Use findLast() when TypeScript stops complaining about it
+        for (let i = data.length - 1; i >= 0; i--) {
+          if (data[i]?.[1] != null) {
+            acc.push(data[i]?.[0]!);
             break;
           }
         }
         return acc;
-      }, []),
+      }, [] as number[]) ?? []),
     );
 
     const minX = Math.min(...endPoints);
@@ -567,11 +570,11 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       return true;
     }
 
-    const { xScale, yScale, xRatio } = this.rescaleEvent;
+    const { xScale, yScale, xRatio } = this.rescaleEvent!;
     const t = 200; // TODO: Use actual size of largest label or average size of all
 
-    const [dx1, dx2] = xScale.domain();
-    const [dy1, dy2] = yScale.domain();
+    const [dx1, dx2] = xScale.domain() as [number, number];
+    const [dy1, dy2] = yScale.domain() as [number, number];
 
     let top = referenceSystem.interpolators.curtain.getIntersects(dy1, 1, 0) as number[][];
     if (top.length === 0) {
@@ -582,8 +585,8 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       bottom = [referenceSystem.interpolators.curtain.getPointAt(1.0) as number[]];
     }
 
-    const maxX = Math.max(top[0][0], bottom[0][0]);
-    const minX = Math.min(top[0][0], bottom[0][0]);
+    const maxX = Math.max(top[0]?.[0]!, bottom[0]?.[0]!);
+    const minX = Math.min(top[0]?.[0]!, bottom[0]?.[0]!);
 
     const wbBBox = {
       left: isXFlipped ? maxX : minX,
@@ -594,7 +597,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
     const screenLeftEdge = dx1 + margin;
     const screenRightEdge = dx2 - margin;
 
-    const [surfaceAreaLeftEdge, surfaceAreaRightEdge] = this.getSurfacesAreaEdges();
+    const [surfaceAreaLeftEdge, surfaceAreaRightEdge] = this.getSurfacesAreaEdges() as [number, number];
 
     const leftLimit = isXFlipped ? Math.min(screenLeftEdge, surfaceAreaLeftEdge) : Math.max(screenLeftEdge, surfaceAreaLeftEdge);
     const rightLimit = isXFlipped ? Math.max(screenRightEdge, surfaceAreaRightEdge) : Math.min(screenRightEdge, surfaceAreaRightEdge);
@@ -608,7 +611,7 @@ export class GeomodelLabelsLayer<T extends SurfaceData> extends CanvasLayer<T> {
       spaceOnLeftSide > spaceOnRightSide ||
       spaceOnLeftSideInScreenCoordinates > t ||
       (spaceOnLeftSideInScreenCoordinates < t && spaceOnRightSideInScreenCoordinates < t && isXFlipped) ||
-      bottom[0][1] < dy1;
+      bottom[0]?.[1]! < dy1;
 
     return isLabelsOnLeftSide;
   }

--- a/src/layers/GeomodelLayerV2.ts
+++ b/src/layers/GeomodelLayerV2.ts
@@ -30,31 +30,31 @@ export class GeomodelLayerV2<T extends SurfaceData> extends PixiLayer<T> {
   }
 
   preRender(): void {
-    const { data }: { data: SurfaceData } = this;
+    const { data } = this;
 
     if (!data) {
       return;
     }
 
-    data.areas.forEach((a: SurfaceArea) => this.generateAreaPolygon(a));
-    data.lines.forEach((l: SurfaceLine) => this.generateSurfaceLine(l));
+    data.areas.forEach((a) => this.generateAreaPolygon(a));
+    data.lines.forEach((l) => this.generateSurfaceLine(l));
 
     this.isPreRendered = true;
   }
 
   createPolygons = (data: number[][]): number[][] => {
     const polygons: number[][] = [];
-    let polygon: number[] = null;
+    let polygon: number[] | undefined;
 
     // Start generating polygons
     for (let i = 0; i < data.length; i++) {
       // Generate top of polygon as long as we have valid values
-      const topIsValid = !!data[i][1];
+      const topIsValid = !!data[i]?.[1];
       if (topIsValid) {
-        if (polygon === null) {
+        if (polygon == null) {
           polygon = [];
         }
-        polygon.push(data[i][0], data[i][1]);
+        polygon.push(data[i]?.[0]!, data[i]?.[1]!);
       }
 
       const endIsReached = i === data.length - 1;
@@ -62,13 +62,13 @@ export class GeomodelLayerV2<T extends SurfaceData> extends PixiLayer<T> {
         if (polygon) {
           // Generate bottom of polygon
           for (let j: number = !topIsValid ? i - 1 : i; j >= 0; j--) {
-            if (!data[j][1]) {
+            if (!data[j]?.[1]) {
               break;
             }
-            polygon.push(data[j][0], data[j][2] || DEFAULT_Y_BOTTOM);
+            polygon.push(data[j]?.[0]!, data[j]?.[2] || DEFAULT_Y_BOTTOM);
           }
           polygons.push(polygon);
-          polygon = null;
+          polygon = undefined;
         }
       }
     }

--- a/src/layers/GeomodelLayerV2.ts
+++ b/src/layers/GeomodelLayerV2.ts
@@ -7,7 +7,7 @@ import { SURFACE_LINE_WIDTH } from '../constants';
 const DEFAULT_Y_BOTTOM = 10000;
 
 export class GeomodelLayerV2<T extends SurfaceData> extends PixiLayer<T> {
-  private isPreRendered: boolean = false;
+  private isPreRendered = false;
 
   override onRescale(event: OnRescaleEvent): void {
     super.onRescale(event);

--- a/src/layers/GridLayer.ts
+++ b/src/layers/GridLayer.ts
@@ -4,10 +4,10 @@ import { ScaleLinear } from 'd3-scale';
 import { LayerOptions } from './base/Layer';
 
 // constants
-const MINORCOLOR: string = 'lightgray';
-const MAJORCOLOR: string = 'gray';
-const MINORWIDTH: number = 0.25;
-const MAJORWIDTH: number = 0.75;
+const MINORCOLOR = 'lightgray';
+const MAJORCOLOR = 'gray';
+const MINORWIDTH = 0.25;
+const MAJORWIDTH = 0.75;
 
 const defaultOptions = {
   minorColor: MINORCOLOR,
@@ -29,8 +29,8 @@ export interface OnGridLayerUpdateEvent<T> extends OnUpdateEvent<T> {
 }
 
 export class GridLayer<T> extends CanvasLayer<T> {
-  private _offsetX: number = 0;
-  private _offsetY: number = 0;
+  private _offsetX = 0;
+  private _offsetY = 0;
 
   constructor(id?: string, options?: GridLayerOptions<T>) {
     super(id, options);

--- a/src/layers/GridLayer.ts
+++ b/src/layers/GridLayer.ts
@@ -65,11 +65,11 @@ export class GridLayer<T> extends CanvasLayer<T> {
       return;
     }
 
-    const xScale = event.xScale.copy();
-    const yScale = event.yScale.copy();
+    const xScale = event.xScale!.copy();
+    const yScale = event.yScale!.copy();
 
-    const xDomain = xScale.domain();
-    const yDomain = yScale.domain();
+    const xDomain = xScale.domain() as [number, number];
+    const yDomain = yScale.domain() as [number, number];
 
     const offsetX = this.offsetX;
     const offsetY = this.offsetY;
@@ -77,8 +77,8 @@ export class GridLayer<T> extends CanvasLayer<T> {
     xScale.domain([xDomain[0] - offsetX, xDomain[1] - offsetX]);
     yScale.domain([yDomain[0] - offsetY, yDomain[1] - offsetY]);
 
-    const [rx1, rx2] = xScale.range();
-    const [ry1, ry2] = yScale.range();
+    const [rx1, rx2] = xScale.range() as [number, number];
+    const [ry1, ry2] = yScale.range() as [number, number];
 
     ctx.lineWidth = minorWidth || MINORWIDTH;
     ctx.strokeStyle = minorColor || MINORCOLOR;
@@ -101,27 +101,31 @@ export class GridLayer<T> extends CanvasLayer<T> {
   private renderTicksX(xscale: ScaleLinear<number, number, never>, xticks: number[], ry1: number, ry2: number): void {
     xticks.forEach((tx: number) => {
       const x = xscale(tx);
-      this.ctx.beginPath();
-      this.ctx.moveTo(x, ry1);
-      this.ctx.lineTo(x, ry2);
-      this.ctx.stroke();
+      if (this.ctx != null) {
+        this.ctx.beginPath();
+        this.ctx.moveTo(x, ry1);
+        this.ctx.lineTo(x, ry2);
+        this.ctx.stroke();
+      }
     });
   }
 
   private renderTicksY(yscale: ScaleLinear<number, number, never>, yticks: number[], rx1: number, rx2: number): void {
     yticks.forEach((ty: number) => {
       const y = yscale(ty);
-      this.ctx.beginPath();
-      this.ctx.moveTo(rx1, y);
-      this.ctx.lineTo(rx2, y);
-      this.ctx.stroke();
+      if (this.ctx != null) {
+        this.ctx.beginPath();
+        this.ctx.moveTo(rx1, y);
+        this.ctx.lineTo(rx2, y);
+        this.ctx.stroke();
+      }
     });
   }
 
   private mapMinorTicks(ticks: number[]): number[] {
     let xminticks: number[] = [];
     if (ticks.length >= 2) {
-      xminticks = ticks.map((v: number) => v + (ticks[1] - ticks[0]) / 2);
+      xminticks = ticks.map((v: number) => v + (ticks[1]! - ticks[0]!) / 2);
       xminticks.pop();
     }
     return xminticks;

--- a/src/layers/ReferenceLineLayer.ts
+++ b/src/layers/ReferenceLineLayer.ts
@@ -16,7 +16,7 @@ export type ReferenceLine = {
   fontSize?: string;
 };
 
-export interface ReferenceLineLayerOptions extends LayerOptions<ReferenceLine[]> {}
+export type ReferenceLineLayerOptions = LayerOptions<ReferenceLine[]>;
 
 const foldReferenceLine = <T>(
   options: {

--- a/src/layers/ReferenceLineLayer.ts
+++ b/src/layers/ReferenceLineLayer.ts
@@ -66,36 +66,41 @@ export class ReferenceLineLayer extends CanvasLayer<ReferenceLine[]> {
   private drawDashed(dashed: ReferenceLine) {
     const { ctx } = this;
     const { canvas } = this;
-    const y = this.yScale(dashed.depth);
-    ctx.save();
-    ctx.strokeStyle = dashed.color;
-    this.setCtxLineStyle(ctx, dashed);
-    this.setCtxLineWidth(ctx, dashed);
-    ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(canvas.width, y);
-    ctx.stroke();
-    ctx.restore();
-    if (dashed.text) {
-      this.drawText(ctx, dashed, ctx.canvas.width, y);
+
+    if (ctx != null && canvas != null) {
+      const y = this.yScale?.(dashed.depth)!;
+      ctx.save();
+      ctx.strokeStyle = dashed.color;
+      this.setCtxLineStyle(ctx, dashed);
+      this.setCtxLineWidth(ctx, dashed);
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvas.width, y);
+      ctx.stroke();
+      ctx.restore();
+      if (dashed.text) {
+        this.drawText(ctx, dashed, ctx.canvas.width, y);
+      }
     }
   }
 
   private drawSolid(solid: ReferenceLine) {
     const { ctx } = this;
     const { canvas } = this;
-    const y = this.yScale(solid.depth);
-    ctx.save();
-    ctx.strokeStyle = solid.color;
-    this.setCtxLineStyle(ctx, solid);
-    this.setCtxLineWidth(ctx, solid);
-    ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(canvas.width, y);
-    ctx.stroke();
-    ctx.restore();
-    if (solid.text) {
-      this.drawText(ctx, solid, ctx.canvas.width, y);
+    const y = this.yScale!(solid.depth);
+    if (ctx != null && canvas != null) {
+      ctx.save();
+      ctx.strokeStyle = solid.color;
+      this.setCtxLineStyle(ctx, solid);
+      this.setCtxLineWidth(ctx, solid);
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvas.width, y);
+      ctx.stroke();
+      ctx.restore();
+      if (solid.text) {
+        this.drawText(ctx, solid, ctx.canvas.width, y);
+      }
     }
   }
 
@@ -103,25 +108,27 @@ export class ReferenceLineLayer extends CanvasLayer<ReferenceLine[]> {
     const factor = 4;
     const min = 2.5;
     const max = 500;
-    const { ctx } = this;
-    const { canvas } = this;
-    const waveHeight = calcSize(factor, min, max, this.yScale);
-    const wavePeriod = waveHeight * 2;
-    const y = this.yScale(wavy.depth) - waveHeight;
-    const steps = Math.ceil(canvas.width / wavePeriod) + 1;
-    const xOffset = this.xScale(0) % wavePeriod;
-    ctx.save();
-    ctx.strokeStyle = wavy.color;
-    this.setCtxLineStyle(ctx, wavy);
-    this.setCtxLineWidth(ctx, wavy);
-    for (let i = -1; i < steps; i++) {
-      ctx.beginPath();
-      ctx.arc(i * wavePeriod + xOffset + waveHeight, y, waveHeight, 0, Math.PI);
-      ctx.stroke();
-    }
-    ctx.restore();
-    if (wavy.text) {
-      this.drawText(ctx, wavy, ctx.canvas.width, y);
+    const { ctx, canvas } = this;
+
+    if (this.xScale != null && this.yScale != null && canvas != null && ctx != null) {
+      const waveHeight = calcSize(factor, min, max, this.yScale);
+      const wavePeriod = waveHeight * 2;
+      const y = this.yScale(wavy.depth) - waveHeight;
+      const steps = Math.ceil(canvas.width / wavePeriod) + 1;
+      const xOffset = this.xScale(0) % wavePeriod;
+      ctx.save();
+      ctx.strokeStyle = wavy.color;
+      this.setCtxLineStyle(ctx, wavy);
+      this.setCtxLineWidth(ctx, wavy);
+      for (let i = -1; i < steps; i++) {
+        ctx.beginPath();
+        ctx.arc(i * wavePeriod + xOffset + waveHeight, y, waveHeight, 0, Math.PI);
+        ctx.stroke();
+      }
+      ctx.restore();
+      if (wavy.text) {
+        this.drawText(ctx, wavy, ctx.canvas.width, y);
+      }
     }
   }
 
@@ -129,12 +136,13 @@ export class ReferenceLineLayer extends CanvasLayer<ReferenceLine[]> {
     const textColor = refLine.textColor || '#000';
     const fontSize = refLine.fontSize || '10px sans-serif';
     const textOffsetX = 10;
+
     ctx.save();
     ctx.strokeStyle = textColor;
     ctx.font = fontSize;
     ctx.textAlign = 'end';
     ctx.textBaseline = 'bottom';
-    ctx.fillText(refLine.text, x - textOffsetX, y);
+    ctx.fillText(refLine.text ?? '', x - textOffsetX, y);
     ctx.restore();
   }
 

--- a/src/layers/WellborePathLayer.ts
+++ b/src/layers/WellborePathLayer.ts
@@ -29,7 +29,7 @@ export interface WellborepathLayerOptions<T extends [number, number][]> extends 
 }
 
 export class WellborepathLayer<T extends [number, number][]> extends SVGLayer<T> {
-  rescaleEvent: OnRescaleEvent;
+  rescaleEvent: OnRescaleEvent | undefined;
 
   constructor(id?: string, options?: WellborepathLayerOptions<T>) {
     super(id, options);
@@ -78,52 +78,54 @@ export class WellborepathLayer<T extends [number, number][]> extends SVGLayer<T>
   }
 
   private renderWellborePath(data: [number, number][]): string {
-    const { xScale, yScale } = this.rescaleEvent;
-    const transformedData: [number, number][] = data.map((d) => [xScale(d[0]), yScale(d[1])]);
+    if (this.rescaleEvent != null) {
+      const { xScale, yScale } = this.rescaleEvent;
+      const transformedData: [number, number][] = data.map((d) => [xScale(d[0]), yScale(d[1])]);
 
-    // TODO: Might be a good idea to move something like this to a shared function in a base class
-    let curveFactory;
-    const { curveType, tension } = this.options as WellborepathLayerOptions<T>;
-    switch (curveType) {
-      default:
-      case 'curveCatmullRom':
-        curveFactory = curveCatmullRom.alpha(tension || CURVE_CATMULL_ROM_ALPHA);
-        break;
-      case 'curveLinear':
-        curveFactory = curveLinear;
-        break;
-      case 'curveBasis':
-        curveFactory = curveBasis;
-        break;
-      case 'curveBasisClosed':
-        curveFactory = curveBasisClosed;
-        break;
-      case 'curveBundle':
-        curveFactory = curveBundle.beta(tension || CURVE_BUNDLE_BETA);
-        break;
-      case 'curveCardinal':
-        curveFactory = curveCardinal.tension(tension || CURVE_CARDINAL_TENSION);
-        break;
-      case 'curveMonotoneX':
-        curveFactory = curveMonotoneX;
-        break;
-      case 'curveMonotoneY':
-        curveFactory = curveMonotoneY;
-        break;
-      case 'curveNatural':
-        curveFactory = curveNatural;
-        break;
-      case 'curveStep':
-        curveFactory = curveStep;
-        break;
-      case 'curveStepAfter':
-        curveFactory = curveStepAfter;
-        break;
-      case 'curveStepBefore':
-        curveFactory = curveStepBefore;
-        break;
+      // TODO: Might be a good idea to move something like this to a shared function in a base class
+      let curveFactory;
+      const { curveType, tension } = this.options as WellborepathLayerOptions<T>;
+      switch (curveType) {
+        default:
+        case 'curveCatmullRom':
+          curveFactory = curveCatmullRom.alpha(tension || CURVE_CATMULL_ROM_ALPHA);
+          break;
+        case 'curveLinear':
+          curveFactory = curveLinear;
+          break;
+        case 'curveBasis':
+          curveFactory = curveBasis;
+          break;
+        case 'curveBasisClosed':
+          curveFactory = curveBasisClosed;
+          break;
+        case 'curveBundle':
+          curveFactory = curveBundle.beta(tension || CURVE_BUNDLE_BETA);
+          break;
+        case 'curveCardinal':
+          curveFactory = curveCardinal.tension(tension || CURVE_CARDINAL_TENSION);
+          break;
+        case 'curveMonotoneX':
+          curveFactory = curveMonotoneX;
+          break;
+        case 'curveMonotoneY':
+          curveFactory = curveMonotoneY;
+          break;
+        case 'curveNatural':
+          curveFactory = curveNatural;
+          break;
+        case 'curveStep':
+          curveFactory = curveStep;
+          break;
+        case 'curveStepAfter':
+          curveFactory = curveStepAfter;
+          break;
+        case 'curveStepBefore':
+          curveFactory = curveStepBefore;
+          break;
+      }
+      return line().curve(curveFactory)(transformedData) ?? '';
     }
-
-    return line().curve(curveFactory)(transformedData);
+    return '';
   }
 }

--- a/src/layers/base/CanvasLayer.ts
+++ b/src/layers/base/CanvasLayer.ts
@@ -3,9 +3,9 @@ import { OnMountEvent, OnUpdateEvent, OnResizeEvent, OnRescaleEvent } from '../.
 import { DEFAULT_LAYER_HEIGHT, DEFAULT_LAYER_WIDTH } from '../../constants';
 
 export abstract class CanvasLayer<T> extends Layer<T> {
-  ctx: CanvasRenderingContext2D;
-  elm: HTMLElement;
-  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D | undefined;
+  elm: HTMLElement | undefined;
+  canvas: HTMLCanvasElement | undefined;
 
   onOpacityChanged(_opacity: number): void {
     if (this.canvas) {
@@ -36,7 +36,7 @@ export abstract class CanvasLayer<T> extends Layer<T> {
     const isVisible = visible || this.isVisible;
     const visibility = isVisible ? 'visible' : 'hidden';
     const interactive = this.interactive ? 'auto' : 'none';
-    this.canvas.setAttribute(
+    this.canvas?.setAttribute(
       'style',
       `position:absolute;pointer-events:${interactive};z-index:${this.order};opacity:${this.opacity};visibility:${visibility}`,
     );
@@ -45,8 +45,8 @@ export abstract class CanvasLayer<T> extends Layer<T> {
   override onMount(event: OnMountEvent): void {
     super.onMount(event);
     const { elm } = event;
-    const width = event.width || parseInt(elm.getAttribute('width'), 10) || DEFAULT_LAYER_WIDTH;
-    const height = event.height || parseInt(elm.getAttribute('height'), 10) || DEFAULT_LAYER_HEIGHT;
+    const width = event.width || parseInt(elm?.getAttribute('width') ?? '', 10) || DEFAULT_LAYER_WIDTH;
+    const height = event.height || parseInt(elm?.getAttribute('height') ?? '', 10) || DEFAULT_LAYER_HEIGHT;
     this.elm = elm;
     let canvas: HTMLCanvasElement;
     if (!this.canvas) {
@@ -59,21 +59,21 @@ export abstract class CanvasLayer<T> extends Layer<T> {
     this.canvas.setAttribute('height', `${height}px`);
     this.canvas.setAttribute('class', 'canvas-layer');
     this.updateStyle();
-    this.ctx = this.canvas.getContext('2d');
+    this.ctx = this.canvas.getContext('2d') ?? undefined;
   }
 
   override onUnmount(): void {
     super.onUnmount();
-    this.canvas.remove();
-    this.canvas = null;
+    this.canvas?.remove();
+    this.canvas = undefined;
   }
 
   override onResize(event: OnResizeEvent): void {
     const { ctx } = this;
     const { width, height } = event;
 
-    ctx.canvas.setAttribute('width', `${width}px`);
-    ctx.canvas.setAttribute('height', `${height}px`);
+    ctx?.canvas.setAttribute('width', `${width}px`);
+    ctx?.canvas.setAttribute('height', `${height}px`);
   }
 
   override onUpdate(event: OnUpdateEvent<T>): void {
@@ -81,22 +81,22 @@ export abstract class CanvasLayer<T> extends Layer<T> {
   }
 
   resetTransform(): void {
-    this.ctx.resetTransform();
+    this.ctx?.resetTransform();
   }
 
   setTransform(event: OnRescaleEvent): void {
     this.resetTransform();
     const flippedX = event.xBounds[0] > event.xBounds[1];
     const flippedY = event.yBounds[0] > event.yBounds[1];
-    this.ctx.translate(event.xScale(0), event.yScale(0));
-    this.ctx.scale(event.xRatio * (flippedX ? -1 : 1), event.yRatio * (flippedY ? -1 : 1));
+    this.ctx?.translate(event.xScale(0), event.yScale(0));
+    this.ctx?.scale(event.xRatio * (flippedX ? -1 : 1), event.yRatio * (flippedY ? -1 : 1));
   }
 
   clearCanvas(): void {
     const { ctx, canvas } = this;
-    ctx.save();
-    ctx.resetTransform();
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.restore();
+    ctx?.save();
+    ctx?.resetTransform();
+    ctx?.clearRect(0, 0, canvas?.width ?? 0, canvas?.height ?? 0);
+    ctx?.restore();
   }
 }

--- a/src/layers/base/HTMLLayer.ts
+++ b/src/layers/base/HTMLLayer.ts
@@ -4,13 +4,13 @@ import { OnMountEvent, OnResizeEvent } from '../../interfaces';
 import { DEFAULT_LAYER_HEIGHT, DEFAULT_LAYER_WIDTH } from '../../constants';
 
 export abstract class HTMLLayer<T> extends Layer<T> {
-  elm: Selection<HTMLElement, unknown, null, undefined>;
+  elm: Selection<HTMLDivElement, unknown, null, undefined> | undefined;
 
   override onMount(event: OnMountEvent): void {
     super.onMount(event);
     const { elm } = event;
-    const width = event.width || parseInt(elm.getAttribute('width'), 10) || DEFAULT_LAYER_WIDTH;
-    const height = event.height || parseInt(elm.getAttribute('height'), 10) || DEFAULT_LAYER_HEIGHT;
+    const width = event.width || parseInt(elm?.getAttribute('width') ?? '', 10) || DEFAULT_LAYER_WIDTH;
+    const height = event.height || parseInt(elm?.getAttribute('height') ?? '', 10) || DEFAULT_LAYER_HEIGHT;
 
     if (!this.elm) {
       this.elm = select(elm).append('div');
@@ -30,8 +30,8 @@ export abstract class HTMLLayer<T> extends Layer<T> {
 
   override onUnmount(): void {
     super.onUnmount();
-    this.elm.remove();
-    this.elm = null;
+    this.elm?.remove();
+    this.elm = undefined;
   }
 
   override onResize(event: OnResizeEvent): void {

--- a/src/layers/base/Layer.ts
+++ b/src/layers/base/Layer.ts
@@ -31,7 +31,7 @@ export abstract class Layer<T> {
   private _referenceSystem: IntersectionReferenceSystem | undefined;
   private _data: T | undefined;
   private _visible: boolean;
-  private _interactive: boolean = false;
+  private _interactive = false;
 
   constructor(id?: string, options?: LayerOptions<T>) {
     this._id = id || `layer-${Math.floor(Math.random() * 1000)}`;
@@ -148,7 +148,7 @@ export abstract class Layer<T> {
    * Clears data and (optionally) the reference system
    * @param includeReferenceSystem - (optional) if true also removes reference system, default is true
    */
-  clearData(includeReferenceSystem: boolean = true): void {
+  clearData(includeReferenceSystem = true): void {
     this._data = undefined;
     if (includeReferenceSystem) {
       this.referenceSystem = undefined;

--- a/src/layers/base/Layer.ts
+++ b/src/layers/base/Layer.ts
@@ -26,10 +26,10 @@ export abstract class Layer<T> {
   private _order: number;
   protected _options: LayerOptions<T>;
   private loading: boolean;
-  private _element?: HTMLElement;
+  private _element: HTMLElement | undefined;
   private _opacity: number;
-  private _referenceSystem?: IntersectionReferenceSystem = null;
-  private _data?: T;
+  private _referenceSystem: IntersectionReferenceSystem | undefined;
+  private _data: T | undefined;
   private _visible: boolean;
   private _interactive: boolean = false;
 
@@ -41,7 +41,7 @@ export abstract class Layer<T> {
       ...opts,
     };
     this.loading = false;
-    this._element = null;
+    this._element = undefined;
     this._opacity = opts.layerOpacity || 1;
     this._visible = true;
     this._interactive = opts.interactive || false;
@@ -49,7 +49,7 @@ export abstract class Layer<T> {
     if (options && options.data) {
       this.setData(options.data);
     }
-    this._referenceSystem = options && options.referenceSystem;
+    this._referenceSystem = options?.referenceSystem;
 
     this.onMount = this.onMount.bind(this);
     this.onUnmount = this.onUnmount.bind(this);
@@ -65,7 +65,7 @@ export abstract class Layer<T> {
     return this._id;
   }
 
-  get element(): HTMLElement {
+  get element(): HTMLElement | undefined {
     return this._element;
   }
 
@@ -112,19 +112,19 @@ export abstract class Layer<T> {
     return this._interactive;
   }
 
-  get referenceSystem(): IntersectionReferenceSystem {
+  get referenceSystem(): IntersectionReferenceSystem | undefined {
     return this._referenceSystem;
   }
 
-  set referenceSystem(referenceSystem: IntersectionReferenceSystem) {
+  set referenceSystem(referenceSystem: IntersectionReferenceSystem | undefined) {
     this._referenceSystem = referenceSystem;
   }
 
-  get data(): T {
+  get data(): T | undefined {
     return this.getData();
   }
 
-  set data(data: T) {
+  set data(data: T | undefined) {
     this.setData(data);
   }
 
@@ -132,14 +132,14 @@ export abstract class Layer<T> {
     return this._visible;
   }
 
-  getData(): T {
+  getData(): T | undefined {
     return this._data;
   }
 
-  setData(data: T): void {
+  setData(data: T | undefined): void {
     this._data = data;
     // should not be called when there is no visual element to work with
-    if (this.element) {
+    if (this.element && data != null) {
       this.onUpdate({ data });
     }
   }
@@ -149,9 +149,9 @@ export abstract class Layer<T> {
    * @param includeReferenceSystem - (optional) if true also removes reference system, default is true
    */
   clearData(includeReferenceSystem: boolean = true): void {
-    this._data = null;
+    this._data = undefined;
     if (includeReferenceSystem) {
-      this.referenceSystem = null;
+      this.referenceSystem = undefined;
     }
     this.onUpdate({});
   }
@@ -168,7 +168,7 @@ export abstract class Layer<T> {
   }
 
   onUnmount(event?: OnUnmountEvent): void {
-    if (this._options.onUnmount) {
+    if (this._options.onUnmount && event != null) {
       this._options.onUnmount(event, this);
     }
   }

--- a/src/layers/base/SVGLayer.ts
+++ b/src/layers/base/SVGLayer.ts
@@ -4,13 +4,13 @@ import { OnMountEvent, OnResizeEvent } from '../../interfaces';
 import { DEFAULT_LAYER_HEIGHT, DEFAULT_LAYER_WIDTH } from '../../constants';
 
 export abstract class SVGLayer<T> extends Layer<T> {
-  elm: Selection<SVGElement, unknown, null, undefined>;
+  elm: Selection<SVGSVGElement, unknown, null, undefined> | undefined;
 
   override onMount(event: OnMountEvent): void {
     super.onMount(event);
     const { elm } = event;
-    const width = event.width || parseInt(elm.getAttribute('width'), 10) || DEFAULT_LAYER_WIDTH;
-    const height = event.height || parseInt(elm.getAttribute('height'), 10) || DEFAULT_LAYER_HEIGHT;
+    const width = event.width || parseInt(elm.getAttribute('width') ?? '', 10) || DEFAULT_LAYER_WIDTH;
+    const height = event.height || parseInt(elm.getAttribute('height') ?? '', 10) || DEFAULT_LAYER_HEIGHT;
     if (!this.elm) {
       this.elm = select(elm).append('svg');
       this.elm.attr('id', `${this.id}`);
@@ -23,8 +23,8 @@ export abstract class SVGLayer<T> extends Layer<T> {
 
   override onUnmount(): void {
     super.onUnmount();
-    this.elm.remove();
-    this.elm = null;
+    this.elm?.remove();
+    this.elm = undefined;
   }
 
   override onResize(event: OnResizeEvent): void {

--- a/src/utils/arc-length.ts
+++ b/src/utils/arc-length.ts
@@ -16,15 +16,8 @@ export class ArcLength {
    * @param {Number} minDepth Min recursive depth before accepting solution
    * @param {Number} maxDepth Max recursive depth
    */
-  static bisect(
-    func: fx,
-    minLimit: number = 0,
-    maxLimit: number = 1,
-    tolerance: number = 0.005,
-    minDepth: number = 4,
-    maxDepth: number = 10,
-  ): number {
-    const calcRec = (a: number, b: number, aVal: number[], bVal: number[], span: number, tolerance: number, depth: number = 0): number => {
+  static bisect(func: fx, minLimit = 0, maxLimit = 1, tolerance = 0.005, minDepth = 4, maxDepth = 10): number {
+    const calcRec = (a: number, b: number, aVal: number[], bVal: number[], span: number, tolerance: number, depth = 0): number => {
       const mid = (a + b) / 2;
       const midVal = func(mid) as number[];
       const spanA = Vector2.distance(aVal, midVal);
@@ -51,7 +44,7 @@ export class ArcLength {
    * @param {Number} maxLimit Max limit
    * @param {Number} segments Number of segments
    */
-  static trapezoid(func: fx, minLimit: number = 0, maxLimit: number = 1, segments: number = 1000): number {
+  static trapezoid(func: fx, minLimit = 0, maxLimit = 1, segments = 1000): number {
     let length = 0;
     let lastPos = func(minLimit) as number[];
     const step = (maxLimit - minLimit) / (segments - 1);

--- a/src/utils/binary-search.ts
+++ b/src/utils/binary-search.ts
@@ -11,10 +11,10 @@ export class BinarySearch {
     while (i > il && i < ih) {
       const v = values[i];
       const v1 = values[i + 1];
-      if (v <= searchValue && v1 >= searchValue) {
+      if (v != null && v1 != null && v <= searchValue && v1 >= searchValue) {
         return i;
       }
-      if (searchValue < v) {
+      if (v != null && searchValue < v) {
         ih = i;
       } else {
         il = i;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,4 +1,4 @@
-import { color, Color } from 'd3-color';
+import { color } from 'd3-color';
 
 const RADIX_SIXTEEN = 16;
 const HEX_STRING_LENGTH = 6;
@@ -6,10 +6,14 @@ const HEX_STRING_LENGTH = 6;
  * Convert color string to number
  */
 export function convertColor(colorStr: string): number {
-  const c: Color = color(colorStr);
-  const d: string = c.formatHex();
-  const n: number = parseInt(d.replace('#', '0x'));
-  return n;
+  const c = color(colorStr);
+  if (c != null) {
+    const d: string = c?.formatHex();
+    const n: number = parseInt(d.replace('#', '0x'));
+    return n;
+  } else {
+    throw Error(`Could not format string ${colorStr} to hex code.`);
+  }
 }
 
 export function colorToCSSColor(color: number | string): string {

--- a/src/utils/root-finder.ts
+++ b/src/utils/root-finder.ts
@@ -15,7 +15,7 @@ export class RootFinder {
    * @param {Number} minLimit Min limit of result
    * @param {Number} maxLimit Max limit of result
    */
-  static newton(func: fx, precision: number = 0.01, maxIterations: number = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number {
+  static newton(func: fx, precision: number = 0.01, maxIterations: number = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number | undefined {
     const h = 0.0001;
     let t = start;
     for (let i = 0; i < maxIterations; i++) {
@@ -26,7 +26,7 @@ export class RootFinder {
       const d = (func(t + h) - v) / h;
       t = t - v / d;
     }
-    return null;
+    return undefined;
   }
 
   /**

--- a/src/utils/root-finder.ts
+++ b/src/utils/root-finder.ts
@@ -15,7 +15,7 @@ export class RootFinder {
    * @param {Number} minLimit Min limit of result
    * @param {Number} maxLimit Max limit of result
    */
-  static newton(func: fx, precision: number = 0.01, maxIterations: number = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number | undefined {
+  static newton(func: fx, precision = 0.01, maxIterations = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number | undefined {
     const h = 0.0001;
     let t = start;
     for (let i = 0; i < maxIterations; i++) {
@@ -38,7 +38,7 @@ export class RootFinder {
    * @param {Number} minLimit Min limit of result
    * @param {Number} maxLimit Max limit of result
    */
-  static bisect(func: fx, precision: number = 0.01, maxIterations: number = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number {
+  static bisect(func: fx, precision = 0.01, maxIterations = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number {
     let tl = minLimit;
     let th = maxLimit;
     let t = start;
@@ -68,7 +68,7 @@ export class RootFinder {
    * @param {Number} minLimit Min limit of result
    * @param {Number} maxLimit Max limit of result
    */
-  static findRoot(func: fx, precision: number = 0.01, maxIterations: number = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number {
+  static findRoot(func: fx, precision = 0.01, maxIterations = 1000, start = 0.5, minLimit = 0, maxLimit = 1): number {
     let t = RootFinder.newton(func, precision, maxIterations, start);
     if (t == null) {
       t = RootFinder.bisect(func, precision, maxIterations, start, minLimit, maxLimit);

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -7,7 +7,7 @@ const DEFAULT_HORIZONTAL_PADDING = 4;
 const DEFAULT_VERTICAL_PADDING = 2;
 
 export function pixelsPerUnit(x: ScaleLinear<number, number>): number {
-  const [min] = x.domain();
+  const [min] = x.domain() as [number, number];
   return Math.abs(x(min + 1));
 }
 
@@ -42,14 +42,14 @@ export function isOverlapping(
   return true;
 }
 
-export function getOverlap(r1: BoundingBox, r2: BoundingBox): { dx: number; dy: number } {
+export function getOverlap(r1: BoundingBox, r2: BoundingBox): { dx: number; dy: number } | undefined {
   const r1x2 = r1.x + r1.width;
   const r2x2 = r2.x + r2.width;
   const r1y2 = r1.y + r1.height;
   const r2y2 = r2.y + r2.height;
 
   if (r2.x > r1x2 || r2.y > r1y2 || r2x2 < r1.x || r2y2 < r1.y) {
-    return null;
+    return undefined;
   }
 
   const dx = Math.max(0, Math.min(r1.x + r1.width, r2.x + r2.width) - Math.max(r1.x, r2.x));
@@ -67,14 +67,14 @@ export function getOverlapOffset(
   r2: BoundingBox,
   horizontalPadding = DEFAULT_HORIZONTAL_PADDING,
   verticalPadding = DEFAULT_VERTICAL_PADDING,
-): { dx: number; dy: number } {
+): { dx: number; dy: number } | undefined {
   const r1x2 = r1.x + r1.width;
   const r2x2 = r2.x + r2.width;
   const r1y2 = r1.y + r1.height;
   const r2y2 = r2.y + r2.height;
 
   if (r2.x - horizontalPadding > r1x2 || r2.y - verticalPadding > r1y2 || r2x2 + horizontalPadding < r1.x || r2y2 + verticalPadding < r1.y) {
-    return null;
+    return undefined;
   }
 
   const dx = r1.x + r1.width - r2.x + horizontalPadding;

--- a/src/utils/vectorUtils.ts
+++ b/src/utils/vectorUtils.ts
@@ -4,9 +4,9 @@ import Vector2 from '@equinor/videx-vector2';
 export const pointToVector = (p: IPoint): Vector2 => new Vector2(p.x, p.y);
 export const pointToArray = (p: IPoint): [number, number] => [p.x, p.y];
 export const vectorToPoint = (v: Vector2): Point => new Point(v[0], v[1]);
-export const vectorToArray = (v: Vector2): [number, number] => [v[0], v[1]];
+export const vectorToArray = (v: Vector2): [number, number] => [v[0] ?? 0, v[1] ?? 0];
 export const arrayToPoint = (a: number[]): Point => new Point(a[0], a[1]);
-export const arrayToVector = (a: number[]): Vector2 => new Vector2(a[0], a[1]);
+export const arrayToVector = (a: number[]): Vector2 => new Vector2(a[0] ?? 0, a[1] ?? 0);
 
 export const calcDist = (prev: [number, number], point: [number, number]): number => {
   return arrayToVector(point).sub(prev).magnitude;
@@ -35,9 +35,12 @@ export const createNormals = (points: IPoint[]): Vector2[] => {
   let n: Vector2;
 
   return points.map((_coord, i, list) => {
-    if (i < list.length - 1) {
-      const p = pointToVector(list[i]);
-      const q = pointToVector(list[i + 1]);
+    const curr = list[i];
+    const next = list[i + 1];
+
+    if (i < list.length - 1 && curr != null && next != null) {
+      const p = pointToVector(curr);
+      const q = pointToVector(next);
       const np = q.sub(p);
       const rotate = np.rotate90();
       n = rotate.normalized();
@@ -62,6 +65,10 @@ export const offsetPoints = (points: IPoint[], vectors: Vector2[], offset: numbe
 
   return points.map((point, index) => {
     const vector = vectors[index];
-    return offsetPoint(point, vector, offset);
+
+    if (vector != null) {
+      return offsetPoint(point, vector, offset);
+    }
+    throw new Error(`Trying to read index ${index} of point ${point}, but no such vector was found!`);
   });
 };

--- a/src/vendor/pixi-dashed-line/index.ts
+++ b/src/vendor/pixi-dashed-line/index.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // https://github.com/davidfig/pixi-dashed-line
 //
 // Copyright 2021 David Figatner

--- a/src/vendor/pixi-dashed-line/index.ts
+++ b/src/vendor/pixi-dashed-line/index.ts
@@ -154,8 +154,8 @@ export class DashLine {
 
       // find the first part of the dash for this line
       const place = this.lineLength % (this.dashSize * this.scale);
-      let dashIndex: number = 0,
-        dashStart: number = 0;
+      let dashIndex = 0,
+        dashStart = 0;
       let dashX = 0;
       for (let i = 0; i < this.dash.length; i++) {
         const dashSize = this.dash[i] * this.scale;

--- a/test/callout-canvas-layer.test.ts
+++ b/test/callout-canvas-layer.test.ts
@@ -46,14 +46,14 @@ describe('CalloutCanvasLayer', () => {
       layer.onUpdate({ data });
       layer.onRescale(rescaleEventStub());
 
-      layer.ctx.__clearEvents();
+      layer.ctx?.__clearEvents();
 
       // Act
       layer.data = data;
       mockRaf.step();
 
       // Assert
-      const events: CanvasRenderingContext2DEvent[] = layer.ctx.__getEvents();
+      const events: CanvasRenderingContext2DEvent[] = layer.ctx?.__getEvents() ?? [];
       const fillTextCalls = events.filter((call: CanvasRenderingContext2DEvent) => call.type === 'fillText');
       expect(fillTextCalls.length).toBeGreaterThanOrEqual(1);
     });
@@ -67,14 +67,14 @@ describe('CalloutCanvasLayer', () => {
       layer.onUpdate({ data });
       layer.onRescale(rescaleEventStub());
 
-      layer.ctx.__clearEvents();
+      layer.ctx?.__clearEvents();
 
       // Act
       layer.data = data;
       mockRaf.step();
 
       // Assert
-      const events: CanvasRenderingContext2DEvent[] = layer.ctx.__getEvents();
+      const events: CanvasRenderingContext2DEvent[] = layer.ctx?.__getEvents() ?? [];
       const fillTextCalls = events.filter((call: CanvasRenderingContext2DEvent) => call.type === 'fillText');
       expect(fillTextCalls.length).toBeGreaterThanOrEqual(1);
     });
@@ -86,7 +86,7 @@ describe('CalloutCanvasLayer', () => {
       layer.onUpdate({ data });
       layer.onRescale(rescaleEventStub());
 
-      layer.ctx.__clearEvents();
+      layer.ctx?.__clearEvents();
 
       // Act
       // Assert

--- a/test/callout-canvas-layer.test.ts
+++ b/test/callout-canvas-layer.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import { describe, expect, it, beforeEach, afterEach, vi, SpyInstance } from 'vitest';
 import { CanvasRenderingContext2DEvent } from 'jest-canvas-mock';
 import createMockRaf from 'mock-raf';

--- a/test/callout.test.ts
+++ b/test/callout.test.ts
@@ -119,9 +119,9 @@ describe('callout', () => {
       const overlap: GraphicObject[] = [];
 
       for (let i = 0; i < arr.length; i++) {
-        const eli = arr[i];
+        const eli = arr[i]!;
         for (let j = 0; j < arr.length; j++) {
-          const elj = arr[j];
+          const elj = arr[j]!;
           if (i !== j) {
             const overlapping = checkForOverlap(eli, elj);
             if (overlapping) {
@@ -181,9 +181,9 @@ describe('callout', () => {
       const overlap: GraphicObjectWithId[] = [];
 
       for (let i = 0; i < arr.length; i++) {
-        const eli = arr[i];
+        const eli = arr[i]!;
         for (let j = 0; j < arr.length; j++) {
-          const elj = arr[j];
+          const elj = arr[j]!;
           if (i !== j) {
             const overlapping = checkForOverlap(eli, elj);
             if (overlapping) {

--- a/test/html-layer.test.ts
+++ b/test/html-layer.test.ts
@@ -52,31 +52,31 @@ describe('HTML', () => {
   it('should have interactive set to false and pointer-events:none by default', () => {
     const layer = new htmlLayer('well');
     layer.onMount({ elm });
-    expect(layer.elm.style('pointer-events')).toEqual('none');
+    expect(layer.elm?.style('pointer-events')).toEqual('none');
     expect(layer.interactive).toEqual(false);
   });
   it('should set pointer-events:auto when setting interactive to true', () => {
     const layer = new htmlLayer('well');
     layer.onMount({ elm });
     layer.interactive = true;
-    expect(layer.elm.style('pointer-events')).toEqual('auto');
+    expect(layer.elm?.style('pointer-events')).toEqual('auto');
   });
   it('should update z-index when changing order', () => {
     const layer = new htmlLayer('well');
     layer.onMount({ elm });
     expect(layer.order).toEqual(1);
-    expect(layer.elm.style('z-index')).toEqual('1');
+    expect(layer.elm?.style('z-index')).toEqual('1');
     layer.order = 2;
     expect(layer.order).toEqual(2);
-    expect(layer.elm.style('z-index')).toEqual('2');
+    expect(layer.elm?.style('z-index')).toEqual('2');
   });
   it('should update opacity when changing its value', () => {
     const layer = new htmlLayer('well');
     layer.onMount({ elm });
     expect(layer.opacity).toEqual(1);
-    expect(layer.elm.style('opacity')).toEqual('1');
+    expect(layer.elm?.style('opacity')).toEqual('1');
     layer.opacity = 0.5;
     expect(layer.opacity).toEqual(0.5);
-    expect(layer.elm.style('opacity')).toEqual('0.5');
+    expect(layer.elm?.style('opacity')).toEqual('0.5');
   });
 });

--- a/test/layer.test.ts
+++ b/test/layer.test.ts
@@ -11,8 +11,8 @@ class TestLayer extends Layer<string> {
   onInteractivityChanged(_interactive: boolean): void {
     throw new Error('Method not implemented.');
   }
-  testString: string = '';
-  updateWasCalled: boolean = false;
+  testString = '';
+  updateWasCalled = false;
   override setData(data: string) {
     super.setData(data);
     this.testString = data;

--- a/test/layer.test.ts
+++ b/test/layer.test.ts
@@ -37,7 +37,7 @@ describe('Layer', () => {
   it('should set data upon construction and not call update when no element has been mounted', () => {
     const layer = new TestLayer('id', { data });
 
-    expect(layer.element).toEqual(null);
+    expect(layer.element).toEqual(undefined);
     expect(layer.data).toEqual('test');
     expect(layer.updateWasCalled).toEqual(false);
   });
@@ -46,7 +46,7 @@ describe('Layer', () => {
 
     layer.setData(data);
 
-    expect(layer.element).toEqual(null);
+    expect(layer.element).toEqual(undefined);
     expect(layer.data).toEqual('test');
     expect(layer.updateWasCalled).toEqual(false);
   });

--- a/test/reference-system.test.ts
+++ b/test/reference-system.test.ts
@@ -11,8 +11,8 @@ const wp = [
 ];
 
 function dist(a: number[], b: number[]): number {
-  const d0 = a[0] - b[0];
-  const d1 = a[1] - b[1];
+  const d0 = a[0]! - b[0]!;
+  const d1 = a[1]! - b[1]!;
   return Math.sqrt(d0 * d0 + d1 * d1);
 }
 
@@ -74,10 +74,10 @@ describe('Reference system', () => {
   });
   it('should have same distance between points in trajectory', () => {
     const trajectory = rs.getTrajectory(80);
-    const firstDistance = dist(trajectory.points[0], trajectory.points[1]);
-    let lastPoint = trajectory.points[1];
+    const firstDistance = dist(trajectory.points[0]!, trajectory.points[1]!);
+    let lastPoint = trajectory.points[1]!;
     for (let i = 2; i < trajectory.points.length; i++) {
-      const point = trajectory.points[i];
+      const point = trajectory.points[i]!;
       const currentDistance = dist(point, lastPoint);
       expect(currentDistance).toBeCloseTo(firstDistance);
       lastPoint = point;
@@ -90,10 +90,10 @@ describe('Reference system', () => {
 
   it('should have same distance between points in extended trajectory', () => {
     const trajectory = rs.getExtendedTrajectory(200, 500.0, 500.0);
-    const firstDistance = dist(trajectory.points[0], trajectory.points[1]);
-    let lastPoint = trajectory.points[1];
+    const firstDistance = dist(trajectory.points[0]!, trajectory.points[1]!);
+    let lastPoint = trajectory.points[1]!;
     for (let i = 2; i < trajectory.points.length; i++) {
-      const point = trajectory.points[i];
+      const point = trajectory.points[i]!;
       const currentDistance = dist(point, lastPoint);
       expect(currentDistance).toBeCloseTo(firstDistance, 0);
       lastPoint = point;
@@ -101,8 +101,8 @@ describe('Reference system', () => {
   });
   it('should have correct length on extension', () => {
     const trajectory = rs.getExtendedTrajectory(100, 500.0, 500.0);
-    const startExtend = dist(trajectory.points[0], rs.interpolators.trajectory.getPointAt(0.0) as number[]);
-    const endExtend = dist(trajectory.points[99], rs.interpolators.trajectory.getPointAt(1.0) as number[]);
+    const startExtend = dist(trajectory.points[0]!, rs.interpolators.trajectory.getPointAt(0.0) as number[]);
+    const endExtend = dist(trajectory.points[99]!, rs.interpolators.trajectory.getPointAt(1.0) as number[]);
     expect(startExtend).toBeCloseTo(500.0);
     expect(endExtend).toBeCloseTo(500.0);
   });
@@ -127,11 +127,13 @@ describe('Reference system', () => {
     const trajectory = irs.getExtendedTrajectory(100, 1500.0, 1500.0);
     expect(trajectory.points.length).toEqual(100);
 
-    const startExtend = dist(trajectory.points[0], irs.interpolators.trajectory.getPointAt(0.0) as number[]);
-    const endExtend = dist(trajectory.points[99], irs.interpolators.trajectory.getPointAt(1.0) as number[]);
+    const startExtend = dist(trajectory.points[0]!, irs.interpolators.trajectory.getPointAt(0.0) as number[]);
+    const endExtend = dist(trajectory.points[99]!, irs.interpolators.trajectory.getPointAt(1.0) as number[]);
     expect(startExtend).toBeCloseTo(1500.0);
     expect(endExtend).toBeCloseTo(1500.0);
-    const angle = degrees(Math.atan((trajectory.points[99][0] - trajectory.points[0][0]) / (trajectory.points[99][1] - trajectory.points[0][1])));
+    const angle = degrees(
+      Math.atan((trajectory.points[99]?.[0]! - trajectory.points[0]?.[0]!) / (trajectory.points[99]?.[1]! - trajectory.points[0]?.[1]!)),
+    );
     expect(angle).toBeCloseTo(45.0);
   });
 

--- a/test/schematicShapeGenerator.test.ts
+++ b/test/schematicShapeGenerator.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import { describe, expect, it } from 'vitest';
 import { Casing, CasingWindow, Completion, HoleSize } from '../src';
 import * as SchematicShapeGenerator from '../src/datautils/schematicShapeGenerator';

--- a/test/svg-layer.test.ts
+++ b/test/svg-layer.test.ts
@@ -64,31 +64,31 @@ describe('SVG', () => {
   it('should have interactive set to false and pointer-events:none by default', () => {
     const layer = new WellborepathLayer('well');
     layer.onMount({ elm });
-    expect(layer.elm.style('pointer-events')).toEqual('none');
+    expect(layer.elm?.style('pointer-events')).toEqual('none');
     expect(layer.interactive).toEqual(false);
   });
   it('should set pointer-events:auto when setting interactive to true', () => {
     const layer = new WellborepathLayer('well');
     layer.onMount({ elm });
     layer.interactive = true;
-    expect(layer.elm.style('pointer-events')).toEqual('auto');
+    expect(layer.elm?.style('pointer-events')).toEqual('auto');
   });
   it('should update z-index when changing order', () => {
     const layer = new WellborepathLayer('well');
     layer.onMount({ elm });
     expect(layer.order).toEqual(1);
-    expect(layer.elm.style('z-index')).toEqual('1');
+    expect(layer.elm?.style('z-index')).toEqual('1');
     layer.order = 2;
     expect(layer.order).toEqual(2);
-    expect(layer.elm.style('z-index')).toEqual('2');
+    expect(layer.elm?.style('z-index')).toEqual('2');
   });
   it('should update opacity when changing its value', () => {
     const layer = new WellborepathLayer('well');
     layer.onMount({ elm });
     expect(layer.opacity).toEqual(1);
-    expect(layer.elm.style('opacity')).toEqual('1');
+    expect(layer.elm?.style('opacity')).toEqual('1');
     layer.opacity = 0.5;
     expect(layer.opacity).toEqual(0.5);
-    expect(layer.elm.style('opacity')).toEqual('0.5');
+    expect(layer.elm?.style('opacity')).toEqual('0.5');
   });
 });

--- a/test/vectorUtils.test.ts
+++ b/test/vectorUtils.test.ts
@@ -14,9 +14,9 @@ describe('vectorUtils', () => {
 
     it('should return a 0 vector for list of only 1 point', () => {
       const normals = createNormals([new Point(1, 1)]);
-      expect(normals[0].x).toEqual(0);
-      expect(normals[0].y).toEqual(0);
-      expect(normals[0].magnitude).toEqual(0);
+      expect(normals[0]?.x).toEqual(0);
+      expect(normals[0]?.y).toEqual(0);
+      expect(normals[0]?.magnitude).toEqual(0);
     });
 
     it('should create a normal for each point', () => {
@@ -30,13 +30,13 @@ describe('vectorUtils', () => {
     it('should calculate vectors', () => {
       const normals = createNormals(points);
       const normal45 = new Vector2(-0.70710678118, 0.70710678118);
-      expect(normals[0].x).toBeCloseTo(normal45.x, 10);
-      expect(normals[0].y).toBeCloseTo(normal45.y, 10);
+      expect(normals[0]?.x).toBeCloseTo(normal45.x, 10);
+      expect(normals[0]?.y).toBeCloseTo(normal45.y, 10);
     });
 
     it('should be normalized', () => {
       const normals = createNormals(points);
-      expect(normals[0].magnitude).toBeCloseTo(1, 10);
+      expect(normals[0]?.magnitude).toBeCloseTo(1, 10);
     });
   });
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     /* Type-Checking */
-    /*"strict": true,*/
+    "strict": true,
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
-    /*"exactOptionalPropertyTypes": true,*/
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
- [ ] add a changeset file (either breaking change or patch version)
- [x] visually verified the features are still working and look visually exactly like the current master branch

# Why enabling strict mode?
- no point in having Typescript without enabling the strictest settings in order to catch typing errors
- Typescript's inference works better with strict mode enabled
- it reported over 1500 of errors that can have undesired behaviour in production and are just bugs waiting to happen in production

# How did I go about it?
- if the fix was straight forward => fix it immediately
- if the above fix ended up in a visual change (or a failing test) => escaping/hide the error with the operator `!`
- if the above needed an obvious API change or I spent too much time changing the implementation fix => escape/hide the error with the operator `!`

# Why hide/escape some of the errors with `!`
The strict mode setting reported over 1500 errors, which if I'd want to properly fix in one PR would be a monstrous task. Using `!` I can effectively leave the code exactly as it is, while keeping the strict mode on by default. 
In future contributions it's encouraged to remove these `!` and fixing the whole type chain in a proper fashion, so essentially (just like today) in the areas where `!` is being used there's potential bug looming. Fixing these bugs be done incrementally.

Currently there's 297 locations where such escape hatches are being used and this number should go down, as relying on `!` is not recommended, because essentially these are locations for "potential" bugs, and if they are correct then the types or interfaces needs changing as well. 